### PR TITLE
Revamp playable flow with new visualizer systems

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,74 +8,105 @@
 </head>
 <body>
     <div id="game-container">
-        <!-- Main Game Canvas -->
-        <canvas id="game-canvas"></canvas>
+        <div id="visualizer-root" aria-hidden="true"></div>
 
-        <!-- HUD Overlay -->
         <div id="hud">
             <div class="hud-top">
-                <div class="hud-score">
-                    <span class="label">SCORE</span>
-                    <span class="value" id="score">0</span>
-                </div>
-                <div class="hud-combo">
-                    <span class="label">COMBO</span>
-                    <span class="value" id="combo">0x</span>
-                </div>
-                <div class="hud-level">
+                <div class="hud-block">
                     <span class="label">LEVEL</span>
-                    <span class="value" id="level">1-1</span>
+                    <span class="value" data-hud="level">—</span>
+                </div>
+                <div class="hud-block">
+                    <span class="label">MODE</span>
+                    <span class="value" data-hud="mode">FACETED</span>
+                </div>
+                <div class="hud-block">
+                    <span class="label">GEOMETRY</span>
+                    <span class="value" data-hud="geometry">HYPERCUBE</span>
+                </div>
+                <div class="hud-block">
+                    <span class="label">SCORE</span>
+                    <span class="value" data-hud="score">0</span>
+                </div>
+                <div class="hud-block">
+                    <span class="label">COMBO</span>
+                    <span class="value" data-hud="combo">—</span>
+                </div>
+                <div class="hud-block compact">
+                    <span class="label">BPM</span>
+                    <span class="value" data-hud="bpm">120 BPM</span>
+                </div>
+                <div class="hud-block compact">
+                    <span class="label">FPS</span>
+                    <span class="value" data-hud="fps">60 FPS</span>
                 </div>
             </div>
 
             <div class="hud-center">
-                <div class="geometry-indicator" id="geometry-display">HYPERCUBE</div>
-                <div class="dimension-meter" id="dimension-meter">
-                    <span class="label">4D</span>
-                    <div class="meter-fill"></div>
+                <div class="geometry-indicator">HYPERCUBE</div>
+                <div class="dimension-meter">
+                    <span class="label">DIMENSION</span>
+                    <div class="meter-track">
+                        <div class="meter-fill" id="dimension-fill" style="--dimension-level:0.5"></div>
+                    </div>
                 </div>
             </div>
 
             <div class="hud-bottom">
-                <div class="health-bar">
-                    <div class="health-fill" id="health"></div>
-                </div>
-                <div class="pulse-meter">
-                    <div class="pulse-fill" id="pulse"></div>
+                <div class="hud-bars">
+                    <div class="bar">
+                        <span class="label">SHIELD</span>
+                        <div class="bar-track">
+                            <div class="bar-fill" data-hud="shield" style="--shield-level:1"></div>
+                        </div>
+                    </div>
+                    <div class="bar">
+                        <span class="label">PULSE</span>
+                        <div class="bar-track">
+                            <div class="bar-fill pulse" data-hud="pulse" style="--pulse-level:0"></div>
+                        </div>
+                    </div>
                 </div>
                 <div class="chaos-indicator">
                     <span class="label">CHAOS</span>
-                    <div class="chaos-level" id="chaos"></div>
+                    <div class="chaos-level" id="chaos-display">0.00</div>
+                </div>
+                <div class="audio-bands">
+                    <div class="band bass" id="bass-band"></div>
+                    <div class="band mid" id="mid-band"></div>
+                    <div class="band high" id="high-band"></div>
                 </div>
             </div>
 
-            <!-- Audio Visualizer -->
-            <div class="audio-bands">
-                <div class="band bass" id="bass-band"></div>
-                <div class="band mid" id="mid-band"></div>
-                <div class="band high" id="high-band"></div>
-            </div>
+            <div class="hud-toast" data-hud="toast"></div>
         </div>
 
-        <!-- Start Screen -->
         <div id="start-screen" class="overlay active">
             <h1>VIB34D RHYTHM ROGUELIKE</h1>
-            <p>Navigate 4D geometric challenges synchronized to your music</p>
+            <p class="tagline">Synchronize 4D lattice challenges to any audio source.</p>
+
+            <div class="start-feedback" aria-live="polite">
+                <p id="start-status" class="feedback-line">Select an audio source to begin.</p>
+                <p id="start-error" class="feedback-line error" role="alert" aria-live="assertive"></p>
+            </div>
 
             <div class="audio-source-select">
                 <h3>Select Audio Source</h3>
                 <button class="source-btn" data-source="mic">🎤 Microphone</button>
                 <button class="source-btn" data-source="file">📁 Audio File</button>
-                <button class="source-btn" data-source="stream">🎵 Stream URL</button>
+                <button class="source-btn" data-source="stream">🌐 Stream URL</button>
             </div>
 
             <input type="file" id="audio-file" accept="audio/*" style="display:none">
             <input type="text" id="stream-url" placeholder="Enter stream URL..." style="display:none">
 
             <button id="start-game" class="primary-btn" disabled>START GAME</button>
+            <div class="start-tips">
+                <p>Tap or click to emit pulses. Long press to bend dimensions.</p>
+                <p>Space pauses. Microphone capture requires HTTPS or localhost.</p>
+            </div>
         </div>
 
-        <!-- Pause Menu -->
         <div id="pause-menu" class="overlay">
             <h2>PAUSED</h2>
             <button id="resume">Resume</button>
@@ -84,7 +115,6 @@
         </div>
     </div>
 
-    <!-- Game Modules -->
     <script type="module" src="src/main.js"></script>
 </body>
 </html>

--- a/src/core/Visualizer.js
+++ b/src/core/Visualizer.js
@@ -1,0 +1,97 @@
+import { CanvasVisualizer } from './visualizers/CanvasVisualizer.js';
+
+const LAYER_SETTINGS = {
+    background: { fade: 0.42, strength: 0.55, hueShift: -30 },
+    shadow: { fade: 0.34, strength: 0.75, hueShift: -12 },
+    content: { fade: 0.22, strength: 1.0, hueShift: 0 },
+    highlight: { fade: 0.16, strength: 1.25, hueShift: 18 },
+    accent: { fade: 0.12, strength: 1.5, hueShift: 32 }
+};
+
+export class IntegratedHolographicVisualizer extends CanvasVisualizer {
+    constructor(canvasId, role, reactivity, variant) {
+        super(canvasId, role, reactivity, variant);
+        const settings = LAYER_SETTINGS[role] || { fade: 0.28, strength: 1, hueShift: 0 };
+        this.fadeAlpha = settings.fade;
+        this.layerStrength = settings.strength;
+        this.layerHueShift = settings.hueShift;
+    }
+
+    drawFrame(ctx, width, height, audio, targets) {
+        const { x: centerX, y: centerY } = this.getCenter(width, height, 0.55);
+        const maxRadius = Math.min(width, height) * (0.58 + this.layerStrength * 0.08);
+        const baseHue = (this.params.hue + this.layerHueShift + this.variant * 14) % 360;
+        const intensity = Math.min(1.6, (this.params.intensity + audio.energy * 1.2) * this.layerStrength);
+        const saturation = Math.min(1, this.params.saturation + audio.high * 0.45);
+
+        // Radial glow
+        ctx.globalAlpha = 0.45;
+        const gradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, maxRadius);
+        gradient.addColorStop(0, `hsla(${(baseHue + 24) % 360}, ${70 + saturation * 20}%, ${25 + intensity * 20}%, 0.8)`);
+        gradient.addColorStop(1, `hsla(${(baseHue - 40) % 360}, ${60 + saturation * 15}%, 6%, 0)`);
+        ctx.fillStyle = gradient;
+        ctx.fillRect(0, 0, width, height);
+        ctx.globalAlpha = 1;
+
+        // Radiating lattice lines
+        const lineCount = Math.max(16, Math.round(this.params.gridDensity * 0.65));
+        const rotation = this.time * 0.24;
+        for (let i = 0; i < lineCount; i++) {
+            const t = i / lineCount;
+            const angle = t * Math.PI * 2 + rotation;
+            const radius = maxRadius * (0.55 + Math.sin(this.time * 0.7 + i) * 0.08 * this.reactivity + audio.bass * 0.35);
+            const x = centerX + Math.cos(angle) * radius;
+            const y = centerY + Math.sin(angle) * radius;
+            const hue = (baseHue + t * 60) % 360;
+            ctx.strokeStyle = `hsla(${hue}, ${62 + saturation * 30}%, ${45 + intensity * 18}%, ${0.11 + intensity * 0.25})`;
+            ctx.lineWidth = 0.8 + intensity * 2;
+            ctx.beginPath();
+            ctx.moveTo(centerX, centerY);
+            ctx.lineTo(x, y);
+            ctx.stroke();
+        }
+
+        // Concentric polytopes
+        const ringCount = 5;
+        const baseSides = 3 + (this.params.geometry % 5);
+        for (let ring = 1; ring <= ringCount; ring++) {
+            const fraction = ring / ringCount;
+            const radius = fraction * maxRadius * (0.65 + audio.mid * 0.35 + this.params.morphFactor * 0.2);
+            const sides = baseSides + (this.variant % 4);
+            ctx.strokeStyle = `hsla(${(baseHue + ring * 12) % 360}, ${65 + saturation * 25}%, ${40 + intensity * 22}%, ${0.09 + intensity * 0.22})`;
+            ctx.lineWidth = 0.7 + intensity * 1.6;
+            ctx.beginPath();
+            for (let side = 0; side <= sides; side++) {
+                const angle = (side / sides) * Math.PI * 2 + this.time * 0.18 + ring * 0.3;
+                const px = centerX + Math.cos(angle) * radius;
+                const py = centerY + Math.sin(angle) * radius;
+                if (side === 0) ctx.moveTo(px, py);
+                else ctx.lineTo(px, py);
+            }
+            ctx.stroke();
+        }
+
+        // Angular highlights
+        const shards = Math.round(8 + this.params.gridDensity * 0.2);
+        for (let i = 0; i < shards; i++) {
+            const radius = maxRadius * (0.2 + (i / shards) * 0.6);
+            const angle = i * (Math.PI * 2 / shards) + this.time * 0.4;
+            const px = centerX + Math.cos(angle) * radius;
+            const py = centerY + Math.sin(angle) * radius;
+            ctx.strokeStyle = `hsla(${(baseHue + 90 + i * 18) % 360}, 80%, ${55 + intensity * 18}%, ${0.08 + intensity * 0.18})`;
+            ctx.lineWidth = 0.5 + intensity * 1.2;
+            ctx.beginPath();
+            ctx.moveTo(centerX, centerY);
+            ctx.lineTo(px, py);
+            ctx.stroke();
+        }
+
+        this.drawTargets(ctx, width, height, targets, {
+            baseHue,
+            intensity,
+            saturation,
+            audio,
+            glow: 1.1 * this.layerStrength
+        });
+    }
+}

--- a/src/core/visualizers/CanvasVisualizer.js
+++ b/src/core/visualizers/CanvasVisualizer.js
@@ -1,0 +1,278 @@
+const DEFAULT_PARAMS = {
+    hue: 200,
+    intensity: 0.5,
+    saturation: 0.8,
+    gridDensity: 15,
+    morphFactor: 1,
+    chaos: 0.2,
+    speed: 1
+};
+
+const FALLBACK_AUDIO = { bass: 0, mid: 0, high: 0, energy: 0 };
+
+export class CanvasVisualizer {
+    constructor(canvasId, role, reactivity = 1, variant = 0) {
+        this.canvas = document.getElementById(canvasId);
+        this.role = role;
+        this.reactivity = Math.max(0.1, reactivity || 1);
+        this.variant = variant || 0;
+        this.isActive = true;
+        this.params = { ...DEFAULT_PARAMS };
+        this.interaction = { x: 0.5, y: 0.5, intensity: 0 };
+        this.pixelRatio = window.devicePixelRatio || 1;
+        this.displayWidth = 1;
+        this.displayHeight = 1;
+        this.fadeAlpha = 0.28;
+        this.time = Math.random() * 10;
+        this.lastRenderTime = performance.now();
+        this.needsResize = true;
+
+        if (this.canvas) {
+            this.canvas.style.width = '100%';
+            this.canvas.style.height = '100%';
+            this.canvas.style.pointerEvents = 'none';
+            this.canvas.setAttribute('aria-hidden', 'true');
+            this.ctx = this.canvas.getContext('2d');
+        } else {
+            this.ctx = null;
+        }
+
+        if (typeof ResizeObserver !== 'undefined' && this.canvas) {
+            this.resizeObserver = new ResizeObserver(() => {
+                this.needsResize = true;
+            });
+            this.resizeObserver.observe(this.canvas);
+        } else {
+            window.addEventListener('resize', () => {
+                this.needsResize = true;
+            });
+        }
+
+        this.applyResize();
+    }
+
+    applyResize() {
+        if (!this.canvas) return;
+        const rect = this.canvas.getBoundingClientRect();
+        const parent = this.canvas.parentElement;
+        const width = rect.width || parent?.clientWidth || window.innerWidth || 1;
+        const height = rect.height || parent?.clientHeight || window.innerHeight || 1;
+        const ratio = window.devicePixelRatio || 1;
+
+        this.displayWidth = Math.max(1, width);
+        this.displayHeight = Math.max(1, height);
+        this.pixelRatio = ratio;
+        this.canvas.width = Math.max(1, Math.floor(this.displayWidth * ratio));
+        this.canvas.height = Math.max(1, Math.floor(this.displayHeight * ratio));
+        this.needsResize = false;
+    }
+
+    updateParameters(params) {
+        if (!params) return;
+        this.params = { ...this.params, ...params };
+    }
+
+    updateInteraction(x, y, intensity = 0) {
+        this.interaction = {
+            x: Math.max(0, Math.min(1, x)),
+            y: Math.max(0, Math.min(1, y)),
+            intensity: Math.max(0, intensity)
+        };
+    }
+
+    setVariant(variant) {
+        this.variant = variant ?? 0;
+    }
+
+    getAudioState() {
+        if (typeof window !== 'undefined' && window.audioReactive) {
+            const { bass = 0, mid = 0, high = 0, energy = 0 } = window.audioReactive;
+            return { bass, mid, high, energy };
+        }
+        return FALLBACK_AUDIO;
+    }
+
+    getCenter(width, height, strength = 0.4) {
+        const clamped = Math.max(0, Math.min(1, strength));
+        return {
+            x: width * (0.5 + (this.interaction.x - 0.5) * clamped * 2),
+            y: height * (0.5 + (this.interaction.y - 0.5) * clamped * 1.5)
+        };
+    }
+
+    render(targets = []) {
+        if (!this.ctx || !this.canvas || !this.isActive) {
+            this.lastRenderTime = performance.now();
+            return;
+        }
+
+        if (this.needsResize) {
+            this.applyResize();
+        }
+
+        const now = performance.now();
+        const dt = Math.min(0.12, Math.max(0.001, (now - this.lastRenderTime) / 1000));
+        this.lastRenderTime = now;
+        const speed = this.params.speed ?? 1;
+        this.time += dt * speed * (0.5 + this.reactivity * 0.5);
+
+        this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+        this.ctx.globalAlpha = Math.max(0.05, Math.min(0.95, this.fadeAlpha));
+        this.ctx.fillStyle = 'rgba(0, 0, 0, 1)';
+        this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.globalAlpha = 1;
+        this.ctx.setTransform(this.pixelRatio, 0, 0, this.pixelRatio, 0, 0);
+        this.ctx.globalCompositeOperation = 'lighter';
+        this.ctx.lineJoin = 'round';
+        this.ctx.lineCap = 'round';
+
+        const audio = this.getAudioState();
+        this.drawFrame(this.ctx, this.displayWidth, this.displayHeight, audio, targets);
+
+        this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+        this.ctx.globalCompositeOperation = 'source-over';
+    }
+
+    drawFrame(ctx, width, height, audio, targets) {
+        // To be implemented by subclasses
+        if (targets?.length) {
+            this.drawTargets(ctx, width, height, targets, { audio });
+        }
+    }
+
+    drawTargets(ctx, width, height, targets, options = {}) {
+        const {
+            baseHue = this.params.hue || 200,
+            intensity = this.params.intensity || 0.5,
+            saturation = this.params.saturation ?? 0.8,
+            audio = this.getAudioState(),
+            glow = 1
+        } = options;
+        const sizeScale = Math.min(width, height);
+
+        targets.forEach((target, index) => {
+            const x = target.x * width;
+            const y = target.y * height;
+            const lifespan = target.lifespan || 1;
+            const life = Math.max(0, Math.min(1, 1 - (target.age || 0) / lifespan));
+            const baseRadius = (target.radius || 0.04) * sizeScale;
+            const pulse = 0.6 + Math.sin(this.time * 3 + index) * 0.4;
+            const geometryHue = (target.metadata?.geometryIndex ?? 0) * 12;
+            const hue = (baseHue + geometryHue + audio.high * 120) % 360;
+            const alpha = Math.min(0.95, 0.25 + intensity * 0.6 + life * 0.5);
+            const strokeAlpha = alpha * 0.85;
+
+            ctx.save();
+            ctx.translate(x, y);
+            ctx.globalAlpha = 0.85;
+            ctx.shadowColor = `hsla(${hue}, ${Math.min(100, 70 + saturation * 30)}%, ${55 + intensity * 25}%, ${0.5 * glow})`;
+            ctx.shadowBlur = baseRadius * (1.4 + intensity) * glow;
+            ctx.lineWidth = Math.max(1.2, baseRadius * 0.28);
+
+            switch (target.type) {
+                case 'belt':
+                case 'ring': {
+                    const widthPx = baseRadius * (target.type === 'belt' ? 4.2 : 3.0);
+                    const heightPx = baseRadius * (target.type === 'belt' ? 1.1 : 0.7);
+                    const radius = heightPx / 2;
+                    ctx.fillStyle = `hsla(${hue}, 80%, 55%, ${alpha})`;
+                    ctx.beginPath();
+                    if (ctx.roundRect) {
+                        ctx.roundRect(-widthPx / 2, -heightPx / 2, widthPx, heightPx, radius);
+                    } else {
+                        ctx.rect(-widthPx / 2, -heightPx / 2, widthPx, heightPx);
+                    }
+                    ctx.fill();
+                    ctx.strokeStyle = `hsla(${hue}, 90%, 75%, ${strokeAlpha})`;
+                    ctx.stroke();
+                    break;
+                }
+                case 'wave': {
+                    const amplitude = baseRadius * (1.1 + audio.mid * 0.6);
+                    const length = baseRadius * 5.5;
+                    const segments = 28;
+                    ctx.strokeStyle = `hsla(${hue}, 80%, 65%, ${strokeAlpha})`;
+                    ctx.lineWidth = baseRadius * 0.35;
+                    ctx.beginPath();
+                    for (let i = 0; i <= segments; i++) {
+                        const t = i / segments;
+                        const px = (t - 0.5) * length;
+                        const py = Math.sin((t * Math.PI * 4) + this.time * 2.2 + index) * amplitude;
+                        if (i === 0) ctx.moveTo(px, py);
+                        else ctx.lineTo(px, py);
+                    }
+                    ctx.stroke();
+                    break;
+                }
+                case 'shard': {
+                    const size = baseRadius * (1.8 + audio.high * 0.6);
+                    ctx.fillStyle = `hsla(${hue}, 90%, 60%, ${alpha})`;
+                    ctx.beginPath();
+                    ctx.moveTo(0, -size * 0.65);
+                    ctx.lineTo(size * 0.55, size * 0.6);
+                    ctx.lineTo(-size * 0.6, size * 0.4);
+                    ctx.closePath();
+                    ctx.fill();
+                    ctx.strokeStyle = `hsla(${hue}, 90%, 75%, ${strokeAlpha})`;
+                    ctx.stroke();
+                    break;
+                }
+                case 'arc': {
+                    const radius = baseRadius * (1.8 + audio.mid * 0.8);
+                    const span = Math.PI * (0.45 + audio.high * 0.4);
+                    ctx.strokeStyle = `hsla(${hue}, 85%, 70%, ${strokeAlpha})`;
+                    ctx.lineWidth = baseRadius * 0.4;
+                    ctx.beginPath();
+                    ctx.arc(0, 0, radius, -span / 2 + this.time, span / 2 + this.time);
+                    ctx.stroke();
+                    break;
+                }
+                case 'chain': {
+                    const segments = 6;
+                    const length = baseRadius * 6;
+                    const sway = Math.sin(this.time * 2 + index) * baseRadius;
+                    ctx.strokeStyle = `hsla(${hue}, 85%, 70%, ${strokeAlpha})`;
+                    ctx.lineWidth = baseRadius * 0.35;
+                    ctx.beginPath();
+                    for (let i = 0; i <= segments; i++) {
+                        const t = i / segments;
+                        const px = (t - 0.5) * length;
+                        const py = Math.sin(this.time * 3 + t * Math.PI * 2 + index) * sway;
+                        if (i === 0) ctx.moveTo(px, py);
+                        else ctx.lineTo(px, py);
+                    }
+                    ctx.stroke();
+                    break;
+                }
+                case 'orb': {
+                    const radius = baseRadius * (1.4 + audio.mid * 0.6);
+                    ctx.strokeStyle = `hsla(${hue}, 85%, 72%, ${strokeAlpha})`;
+                    ctx.lineWidth = baseRadius * 0.32;
+                    ctx.beginPath();
+                    ctx.arc(0, 0, radius, 0, Math.PI * 2);
+                    ctx.stroke();
+                    ctx.fillStyle = `hsla(${hue}, 85%, ${45 + intensity * 25}%, ${alpha})`;
+                    ctx.beginPath();
+                    ctx.arc(0, 0, radius * (0.4 + pulse * 0.4), 0, Math.PI * 2);
+                    ctx.fill();
+                    break;
+                }
+                default: {
+                    const radius = baseRadius * (1.2 + audio.energy * 0.7);
+                    ctx.fillStyle = `hsla(${hue}, 85%, ${45 + intensity * 30}%, ${alpha})`;
+                    ctx.beginPath();
+                    ctx.arc(0, 0, radius * pulse, 0, Math.PI * 2);
+                    ctx.fill();
+                    ctx.strokeStyle = `hsla(${hue}, 90%, 70%, ${strokeAlpha})`;
+                    ctx.lineWidth = baseRadius * 0.35;
+                    ctx.beginPath();
+                    ctx.arc(0, 0, radius * (1.25 + audio.high * 0.4), 0, Math.PI * 2);
+                    ctx.stroke();
+                    break;
+                }
+            }
+
+            ctx.restore();
+        });
+    }
+}

--- a/src/game/modes/ModeController.js
+++ b/src/game/modes/ModeController.js
@@ -98,12 +98,12 @@ export class ModeController {
         return this.parameterManager.getAllParameters();
     }
 
-    render(interaction) {
+    render(interaction, targets = []) {
         const renderer = this.modeRenderers.get(this.activeMode);
         if (!renderer) return;
         if (interaction) {
             renderer.updateInteraction(interaction);
         }
-        renderer.render();
+        renderer.render(targets);
     }
 }

--- a/src/game/modes/ModeRenderer.js
+++ b/src/game/modes/ModeRenderer.js
@@ -83,11 +83,11 @@ export class ModeRenderer {
         });
     }
 
-    render() {
+    render(targets = []) {
         if (!this.active) return;
         this.visualizers.forEach(visualizer => {
             if (visualizer?.render) {
-                visualizer.render();
+                visualizer.render(targets);
             }
         });
     }

--- a/src/holograms/HolographicVisualizer.js
+++ b/src/holograms/HolographicVisualizer.js
@@ -1,0 +1,92 @@
+import { CanvasVisualizer } from '../core/visualizers/CanvasVisualizer.js';
+
+const LAYER_SETTINGS = {
+    background: { fade: 0.36, strength: 0.6, hueShift: -10 },
+    shadow: { fade: 0.28, strength: 0.85, hueShift: 0 },
+    content: { fade: 0.18, strength: 1.1, hueShift: 12 },
+    highlight: { fade: 0.14, strength: 1.35, hueShift: 26 },
+    accent: { fade: 0.1, strength: 1.6, hueShift: 42 }
+};
+
+export class HolographicVisualizer extends CanvasVisualizer {
+    constructor(canvasId, role, reactivity, variant) {
+        super(canvasId, role, reactivity, variant);
+        const settings = LAYER_SETTINGS[role] || { fade: 0.24, strength: 1, hueShift: 0 };
+        this.fadeAlpha = settings.fade;
+        this.layerStrength = settings.strength;
+        this.layerHueShift = settings.hueShift;
+        this.starSeed = Math.random() * 1000;
+    }
+
+    drawFrame(ctx, width, height, audio, targets) {
+        const { x: centerX, y: centerY } = this.getCenter(width, height, 0.5);
+        const maxRadius = Math.min(width, height) * (0.62 + this.layerStrength * 0.12);
+        const baseHue = (this.params.hue + this.layerHueShift + this.variant * 8) % 360;
+        const intensity = Math.min(1.9, (this.params.intensity + audio.energy * 1.5) * this.layerStrength);
+        const saturation = Math.min(1, this.params.saturation + audio.high * 0.55);
+
+        // Star field shimmer
+        ctx.globalAlpha = 0.9;
+        const starCount = 80;
+        for (let i = 0; i < starCount; i++) {
+            const t = i / starCount;
+            const angle = t * Math.PI * 12 + this.time * (0.4 + this.reactivity * 0.2);
+            const radius = (0.15 + t * 0.85) * maxRadius * (0.9 + audio.mid * 0.2);
+            const px = centerX + Math.cos(angle + this.starSeed) * radius;
+            const py = centerY + Math.sin(angle + this.starSeed) * radius;
+            const hue = (baseHue + 60 + i * 4) % 360;
+            const alpha = 0.05 + intensity * 0.12;
+            ctx.fillStyle = `hsla(${hue}, ${70 + saturation * 25}%, ${55 + intensity * 20}%, ${alpha})`;
+            ctx.beginPath();
+            ctx.arc(px, py, 1.5 + Math.sin(this.time * 3 + i) * 0.8, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        ctx.globalAlpha = 1;
+
+        // Holographic rings
+        const ringCount = 6;
+        for (let r = 0; r < ringCount; r++) {
+            const fraction = r / ringCount;
+            const radius = maxRadius * (0.25 + fraction * 0.7 + audio.bass * 0.25);
+            const hue = (baseHue + 120 + r * 18) % 360;
+            ctx.strokeStyle = `hsla(${hue}, ${70 + saturation * 25}%, ${40 + intensity * 25}%, ${0.08 + intensity * 0.18})`;
+            ctx.lineWidth = 1.1 + intensity * 1.5;
+            ctx.beginPath();
+            ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+            ctx.stroke();
+        }
+
+        // Light sweeps
+        const sweepCount = 4;
+        for (let i = 0; i < sweepCount; i++) {
+            const sweepAngle = this.time * 0.8 + i * (Math.PI / 2);
+            const hue = (baseHue + i * 30) % 360;
+            ctx.strokeStyle = `hsla(${hue}, ${60 + saturation * 20}%, ${55 + intensity * 20}%, ${0.06 + intensity * 0.15})`;
+            ctx.lineWidth = 2.2 + intensity * 2.2;
+            ctx.beginPath();
+            const arcSpan = Math.PI * (0.4 + audio.high * 0.45);
+            ctx.arc(centerX, centerY, maxRadius * 0.85, sweepAngle - arcSpan / 2, sweepAngle + arcSpan / 2);
+            ctx.stroke();
+        }
+
+        // Pulse bloom
+        const bloomRadius = maxRadius * (0.3 + audio.energy * 0.45);
+        ctx.globalAlpha = 0.4;
+        const bloomGradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, bloomRadius * 1.4);
+        bloomGradient.addColorStop(0, `hsla(${baseHue}, ${70 + saturation * 20}%, ${55 + intensity * 20}%, 0.55)`);
+        bloomGradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+        ctx.fillStyle = bloomGradient;
+        ctx.beginPath();
+        ctx.arc(centerX, centerY, bloomRadius * 1.4, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.globalAlpha = 1;
+
+        this.drawTargets(ctx, width, height, targets, {
+            baseHue,
+            intensity,
+            saturation,
+            audio,
+            glow: 1.45 * this.layerStrength
+        });
+    }
+}

--- a/src/quantum/QuantumVisualizer.js
+++ b/src/quantum/QuantumVisualizer.js
@@ -1,0 +1,112 @@
+import { CanvasVisualizer } from '../core/visualizers/CanvasVisualizer.js';
+
+const LAYER_SETTINGS = {
+    background: { fade: 0.38, strength: 0.6, hueShift: 60 },
+    shadow: { fade: 0.3, strength: 0.8, hueShift: 80 },
+    content: { fade: 0.18, strength: 1.15, hueShift: 100 },
+    highlight: { fade: 0.14, strength: 1.35, hueShift: 120 },
+    accent: { fade: 0.1, strength: 1.55, hueShift: 140 }
+};
+
+export class QuantumHolographicVisualizer extends CanvasVisualizer {
+    constructor(canvasId, role, reactivity, variant) {
+        super(canvasId, role, reactivity, variant);
+        const settings = LAYER_SETTINGS[role] || { fade: 0.26, strength: 1, hueShift: 80 };
+        this.fadeAlpha = settings.fade;
+        this.layerStrength = settings.strength;
+        this.layerHueShift = settings.hueShift;
+    }
+
+    drawFrame(ctx, width, height, audio, targets) {
+        const { x: centerX, y: centerY } = this.getCenter(width, height, 0.4);
+        const maxRadius = Math.min(width, height) * (0.55 + this.layerStrength * 0.1);
+        const baseHue = (this.params.hue + this.layerHueShift + this.variant * 10) % 360;
+        const intensity = Math.min(1.8, (this.params.intensity + audio.energy * 1.4) * this.layerStrength);
+        const saturation = Math.min(1, this.params.saturation + audio.high * 0.6);
+
+        // Quantum lattice grid
+        const columns = Math.max(6, Math.round(this.params.gridDensity * 0.35));
+        const rows = Math.max(6, Math.round(this.params.gridDensity * 0.28));
+        const timeOffset = this.time * 0.4;
+        const cellWidth = width / columns;
+        const cellHeight = height / rows;
+
+        ctx.globalAlpha = 0.85;
+        for (let c = 0; c <= columns; c++) {
+            const x = c * cellWidth;
+            const wave = Math.sin(timeOffset + c * 0.4) * cellWidth * 0.3 * this.reactivity;
+            ctx.strokeStyle = `hsla(${(baseHue + c * 4) % 360}, ${70 + saturation * 20}%, ${35 + intensity * 20}%, ${0.05 + intensity * 0.18})`;
+            ctx.lineWidth = 0.6 + intensity * 1.2;
+            ctx.beginPath();
+            for (let r = 0; r <= rows; r++) {
+                const y = r * cellHeight + Math.sin(timeOffset + r * 0.45 + c * 0.2) * cellHeight * 0.25 * this.reactivity;
+                const px = x + wave * Math.sin(timeOffset * 1.5 + r * 0.4);
+                if (r === 0) ctx.moveTo(px, y);
+                else ctx.lineTo(px, y);
+            }
+            ctx.stroke();
+        }
+
+        for (let r = 0; r <= rows; r++) {
+            const y = r * cellHeight;
+            const wave = Math.cos(timeOffset + r * 0.38) * cellHeight * 0.3 * this.reactivity;
+            ctx.strokeStyle = `hsla(${(baseHue + 40 + r * 5) % 360}, ${65 + saturation * 25}%, ${30 + intensity * 18}%, ${0.05 + intensity * 0.18})`;
+            ctx.lineWidth = 0.6 + intensity;
+            ctx.beginPath();
+            for (let c = 0; c <= columns; c++) {
+                const x = c * cellWidth + Math.cos(timeOffset + c * 0.5 + r * 0.25) * cellWidth * 0.25 * this.reactivity;
+                const py = y + wave * Math.cos(timeOffset * 1.4 + c * 0.35);
+                if (c === 0) ctx.moveTo(x, py);
+                else ctx.lineTo(x, py);
+            }
+            ctx.stroke();
+        }
+        ctx.globalAlpha = 1;
+
+        // Particle wells
+        const nodeCount = Math.round(24 + this.params.gridDensity * 0.4);
+        for (let i = 0; i < nodeCount; i++) {
+            const angle = i * (Math.PI * 2 / nodeCount) + this.time * 0.6;
+            const radius = maxRadius * (0.2 + (i % 7) * 0.08 + audio.bass * 0.25);
+            const px = centerX + Math.cos(angle) * radius;
+            const py = centerY + Math.sin(angle) * radius;
+            const hue = (baseHue + 80 + i * 8) % 360;
+            const alpha = 0.12 + intensity * 0.18;
+            const size = 6 + Math.sin(this.time * 1.8 + i) * 3;
+
+            ctx.fillStyle = `hsla(${hue}, ${70 + saturation * 25}%, ${55 + intensity * 15}%, ${alpha})`;
+            ctx.beginPath();
+            ctx.arc(px, py, size, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        // Quantum field swirls
+        const swirlCount = 6;
+        for (let i = 0; i < swirlCount; i++) {
+            const phase = this.time * 0.8 + i * Math.PI * 0.66;
+            const radius = maxRadius * (0.4 + i * 0.08 + audio.mid * 0.25);
+            const hue = (baseHue + 140 + i * 25) % 360;
+            ctx.strokeStyle = `hsla(${hue}, ${70 + saturation * 20}%, ${45 + intensity * 15}%, ${0.08 + intensity * 0.2})`;
+            ctx.lineWidth = 1 + intensity * 1.4;
+            ctx.beginPath();
+            for (let t = 0; t <= 32; t++) {
+                const angle = t / 32 * Math.PI * 2 + phase;
+                const modulation = Math.sin(angle * 3 + this.time * 1.5) * 0.18 * this.reactivity;
+                const px = centerX + Math.cos(angle) * radius * (1 + modulation);
+                const py = centerY + Math.sin(angle) * radius * (1 - modulation);
+                if (t === 0) ctx.moveTo(px, py);
+                else ctx.lineTo(px, py);
+            }
+            ctx.closePath();
+            ctx.stroke();
+        }
+
+        this.drawTargets(ctx, width, height, targets, {
+            baseHue,
+            intensity,
+            saturation,
+            audio,
+            glow: 1.3 * this.layerStrength
+        });
+    }
+}

--- a/styles/game.css
+++ b/styles/game.css
@@ -28,14 +28,28 @@ body {
     background: linear-gradient(45deg, #0a0015, #1a001a, #000030);
 }
 
-/* Main Game Canvas */
-#game-canvas {
+/* Visualizer Layers */
+#visualizer-root {
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
+    overflow: hidden;
+    z-index: 1;
+}
+
+.mode-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    mix-blend-mode: screen;
+    z-index: 2;
+}
+
+.visual-canvas {
+    position: absolute;
+    inset: 0;
     width: 100%;
     height: 100%;
-    background: transparent;
+    display: block;
 }
 
 /* HUD System */
@@ -53,31 +67,39 @@ body {
 .hud-top {
     position: absolute;
     top: 20px;
-    left: 0;
-    right: 0;
+    left: 20px;
+    right: 20px;
     display: flex;
-    justify-content: space-between;
-    padding: 0 30px;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: center;
 }
 
-.hud-score, .hud-combo, .hud-level {
+.hud-block {
     display: flex;
     flex-direction: column;
     align-items: center;
-    background: rgba(0, 0, 0, 0.8);
-    padding: 10px 15px;
-    border: 2px solid #00ffff;
-    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.75);
+    padding: 10px 14px;
+    border: 2px solid rgba(0, 255, 255, 0.6);
+    border-radius: 10px;
     min-width: 80px;
+    backdrop-filter: blur(6px);
 }
 
-.hud-score .label, .hud-combo .label, .hud-level .label {
-    font-size: 10px;
-    color: #888;
-    margin-bottom: 5px;
+.hud-block.compact {
+    min-width: 70px;
+    padding: 8px 12px;
 }
 
-.hud-score .value, .hud-combo .value, .hud-level .value {
+.hud-block .label {
+    font-size: 11px;
+    color: #8ac5ff;
+    letter-spacing: 1px;
+    margin-bottom: 4px;
+}
+
+.hud-block .value {
     font-size: 18px;
     font-weight: bold;
     color: #00ffff;
@@ -108,11 +130,7 @@ body {
 }
 
 .dimension-meter {
-    width: 200px;
-    height: 8px;
-    background: rgba(255, 255, 255, 0.2);
-    border-radius: 4px;
-    overflow: hidden;
+    width: 240px;
     margin: 0 auto;
 }
 
@@ -124,12 +142,30 @@ body {
     margin-bottom: 5px;
 }
 
+.dimension-meter .meter-track {
+    width: 100%;
+    height: 10px;
+    background: rgba(255, 255, 255, 0.18);
+    border-radius: 6px;
+    overflow: hidden;
+}
+
 .dimension-meter .meter-fill {
+    width: 100%;
     height: 100%;
     background: linear-gradient(90deg, #00ffff, #ff00ff);
-    width: 50%;
-    transition: width 0.3s ease;
-    border-radius: 4px;
+    transform: scaleX(var(--dimension-level, 0.5));
+    transform-origin: left center;
+    transition: transform 0.25s ease;
+}
+
+.dimension-meter .meter-fill::after {
+    content: '';
+    display: block;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0.4), transparent);
+    mix-blend-mode: screen;
 }
 
 /* HUD Bottom Bar */
@@ -140,42 +176,45 @@ body {
     right: 30px;
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-end;
 }
 
-/* Health Bar */
-.health-bar {
-    width: 200px;
-    height: 12px;
-    background: rgba(255, 255, 255, 0.2);
-    border-radius: 6px;
-    overflow: hidden;
+.hud-bars {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
 }
 
-.health-fill {
-    height: 100%;
-    background: #4ade80;
+.bar {
+    min-width: 220px;
+}
+
+.bar .label {
+    font-size: 11px;
+    color: #8ac5ff;
+    margin-bottom: 6px;
+}
+
+.bar-track {
     width: 100%;
-    transition: all 0.3s ease;
+    height: 12px;
+    background: rgba(255, 255, 255, 0.18);
     border-radius: 6px;
-}
-
-/* Pulse Meter */
-.pulse-meter {
-    width: 150px;
-    height: 8px;
-    background: rgba(255, 255, 255, 0.2);
-    border-radius: 4px;
     overflow: hidden;
 }
 
-.pulse-fill {
+.bar-fill {
+    width: 100%;
     height: 100%;
-    background: linear-gradient(90deg, #ff0080, #ff8000);
-    width: 0%;
-    transition: width 0.1s ease;
-    border-radius: 4px;
-    opacity: 0.8;
+    background: linear-gradient(90deg, #02ffc7, #00b7ff);
+    transform: scaleX(var(--shield-level, 1));
+    transform-origin: left center;
+    transition: transform 0.2s ease;
+}
+
+.bar-fill.pulse {
+    background: linear-gradient(90deg, #ff0080, #ffb400);
+    transform: scaleX(var(--pulse-level, 0));
 }
 
 /* Chaos Indicator */
@@ -196,6 +235,29 @@ body {
     font-size: 12px;
     color: #00ff00;
     letter-spacing: 1px;
+}
+
+.hud-toast {
+    position: absolute;
+    bottom: 45%;
+    left: 50%;
+    transform: translate(-50%, 0) scale(0.9);
+    background: rgba(0, 0, 0, 0.85);
+    color: #fff;
+    padding: 14px 24px;
+    border-radius: 12px;
+    font-weight: bold;
+    letter-spacing: 1px;
+    opacity: 0;
+    transition: all 0.3s ease;
+    pointer-events: none;
+    border: 2px solid rgba(0, 255, 255, 0.4);
+    box-shadow: 0 0 20px rgba(0, 255, 255, 0.3);
+}
+
+.hud-toast.visible {
+    opacity: 1;
+    transform: translate(-50%, -10px) scale(1);
 }
 
 /* Audio Visualizer */
@@ -265,10 +327,53 @@ body {
     margin-bottom: 20px;
 }
 
-#start-screen p {
+#start-screen .tagline {
     font-size: 18px;
-    color: #888;
-    margin-bottom: 40px;
+    color: #8fa5ff;
+    margin-bottom: 24px;
+}
+
+.start-feedback {
+    min-height: 64px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 24px;
+}
+
+.feedback-line {
+    font-size: 16px;
+    color: #bcd6ff;
+    min-height: 20px;
+    transition: color 0.2s ease;
+    max-width: 480px;
+}
+
+.feedback-line.success {
+    color: #7dffcf;
+}
+
+.feedback-line.warning {
+    color: #ffd26f;
+}
+
+.feedback-line.error {
+    color: #ff7070;
+    font-weight: bold;
+}
+
+.start-tips {
+    margin-top: 36px;
+    color: #666;
+    font-size: 14px;
+    line-height: 1.6;
+    max-width: 460px;
+}
+
+.start-tips p + p {
+    margin-top: 6px;
 }
 
 .audio-source-select {
@@ -279,6 +384,26 @@ body {
     color: #fff;
     margin-bottom: 20px;
     font-size: 20px;
+}
+
+#start-screen input[type="file"],
+#start-screen input[type="text"] {
+    margin-top: 10px;
+    padding: 12px 16px;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.4);
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    font-family: inherit;
+    width: clamp(280px, 32vw, 360px);
+    text-align: center;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+#start-screen input[type="text"]:focus {
+    outline: none;
+    border-color: #00ffff;
+    box-shadow: 0 0 12px rgba(0, 255, 255, 0.4);
 }
 
 .source-btn {
@@ -329,6 +454,12 @@ body {
     opacity: 0.5;
     cursor: not-allowed;
     transform: none;
+}
+
+.primary-btn.loading {
+    position: relative;
+    opacity: 0.7;
+    pointer-events: none;
 }
 
 /* Pause Menu */
@@ -465,16 +596,17 @@ body.beat-flash {
 /* Responsive Design */
 @media (max-width: 768px) {
     .hud-top {
-        padding: 0 15px;
-        top: 10px;
+        top: 12px;
+        left: 12px;
+        right: 12px;
     }
 
-    .hud-score, .hud-combo, .hud-level {
-        padding: 8px 12px;
-        min-width: 60px;
+    .hud-block {
+        min-width: 64px;
+        padding: 8px 10px;
     }
 
-    .hud-score .value, .hud-combo .value, .hud-level .value {
+    .hud-block .value {
         font-size: 14px;
     }
 
@@ -483,28 +615,30 @@ body.beat-flash {
     }
 
     .dimension-meter {
-        width: 150px;
+        width: 180px;
     }
 
     .hud-bottom {
-        bottom: 20px;
-        left: 15px;
-        right: 15px;
+        bottom: 18px;
+        left: 16px;
+        right: 16px;
+        flex-direction: column;
+        gap: 18px;
+        align-items: stretch;
     }
 
-    .health-bar {
-        width: 150px;
-        height: 10px;
+    .hud-bars {
+        width: 100%;
     }
 
-    .pulse-meter {
-        width: 100px;
-        height: 6px;
+    .bar {
+        min-width: unset;
     }
 
     .audio-bands {
-        bottom: 20px;
-        right: 15px;
+        align-self: center;
+        bottom: auto;
+        right: auto;
         height: 40px;
     }
 


### PR DESCRIPTION
## Summary
- replace the front-end bootstrap with a menu-driven GameBootstrap that wires the HUD, pause flow, and the existing LatticePulseGame systems together
- add lightweight CanvasVisualizer infrastructure plus faceted, quantum, and holographic renderers that draw beat targets directly on the new visualizer stack
- extend AudioService with microphone and file support while refreshing the HUD/start screen styling to match the new data hooks

## Testing
- not run (project has no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68d3764d6ff8832981ca453c714171ea