### PR TITLE
feat: orchestrate layered feedback effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ Energy → visual feedback → Timing windows
 - Safari 12+
 - Mobile browsers with WebGL support
 
+## 📱 Mobile Experience
+
+- **Adaptive Profiles**: Auto-detects device tiers (flagship, performance, battery) and tunes render scale, shader density, and audio analysis fidelity accordingly.
+- **Touch Enhancements**: On-screen control center for graphics quality, haptics, and tilt steering toggles built for thumb-friendly access.
+- **Performance Telemetry**: Live FPS and audio latency readouts help players monitor headroom while the engine auto-balances detail.
+- **Orientation Awareness**: Smart overlay guides players to rotate into hyperwide landscape when needed.
+- **Session Persistence**: Remembers last audio source, stream URL, and preferred mobile settings across launches.
+
 ## 🎵 Audio Support
 
 ### **Input Sources**

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 
         <!-- HUD Overlay -->
         <div id="hud">
+            <div id="feedback-layer" class="feedback-layer"></div>
             <div class="hud-top">
                 <div class="hud-score">
                     <span class="label">SCORE</span>
@@ -55,6 +56,33 @@
                 <div class="band mid" id="mid-band"></div>
                 <div class="band high" id="high-band"></div>
             </div>
+        </div>
+
+        <!-- Mobile Experience Layer -->
+        <div id="mobile-ux" class="mobile-ux">
+            <div class="status-row">
+                <div class="status-chip" id="mobile-performance-status">-- FPS</div>
+                <div class="status-chip">Latency: <span id="latency-value">interactive</span></div>
+            </div>
+            <div class="control-row">
+                <span class="row-label">Graphics</span>
+                <div class="chip-group">
+                    <button class="chip active" data-graphics-profile="auto">AUTO</button>
+                    <button class="chip" data-graphics-profile="battery">BATTERY</button>
+                    <button class="chip" data-graphics-profile="ultra">ULTRA</button>
+                </div>
+            </div>
+            <div class="control-row">
+                <span class="row-label">Touch Enhancements</span>
+                <div class="chip-group">
+                    <button class="chip" id="toggle-haptics">HAPTICS</button>
+                    <button class="chip active" id="toggle-tilt">TILT ✓</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="orientation-warning" class="orientation-warning hidden">
+            <span>Rotate for Hyperwide Mode</span>
         </div>
 
         <!-- Start Screen -->

--- a/src/core/Parameters.js
+++ b/src/core/Parameters.js
@@ -88,6 +88,51 @@ export class ParameterManager {
             this.setParameter(name, value);
         }
     }
+
+    /**
+     * Apply a named or inline profile to the current parameter set.
+     * Accepts either an object with parameter overrides or a profile name.
+     */
+    applyProfile(profile) {
+        const profiles = {
+            battery: {
+                gridDensity: 12,
+                chaos: 0.15,
+                intensity: 0.5,
+                speed: 0.85
+            },
+            mobile: {
+                gridDensity: 18,
+                chaos: 0.22,
+                intensity: 0.65,
+                speed: 1.0
+            },
+            ultra: {
+                gridDensity: 26,
+                chaos: 0.3,
+                intensity: 0.85,
+                saturation: 0.95
+            }
+        };
+
+        let overrides = {};
+
+        if (typeof profile === 'string') {
+            overrides = profiles[profile] || {};
+        } else if (profile && typeof profile === 'object') {
+            overrides = profile;
+        }
+
+        if (!overrides || !Object.keys(overrides).length) {
+            return;
+        }
+
+        Object.entries(overrides).forEach(([key, value]) => {
+            if (this.parameterDefs[key]) {
+                this.setParameter(key, value);
+            }
+        });
+    }
     
     /**
      * Get a specific parameter value

--- a/src/game/audio/AudioService.js
+++ b/src/game/audio/AudioService.js
@@ -20,18 +20,33 @@ export class AudioService {
         this.energyHistory = [];
         this.historySize = 43; // ~0.7 seconds at 60fps
         this.metronomeEnabled = true;
+        this.latencyHint = 'interactive';
+        this.targetSampleRate = null;
+        this.qualityPreset = 'standard';
+        this.analysisSmoothing = 0.8;
+        this.volumeCeiling = 0.85;
     }
 
     async init() {
         if (this.context) return;
-        this.context = new (window.AudioContext || window.webkitAudioContext)();
+        const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+        const options = {};
+        if (this.latencyHint) options.latencyHint = this.latencyHint;
+        if (this.targetSampleRate) options.sampleRate = this.targetSampleRate;
+
+        try {
+            this.context = new AudioContextClass(options);
+        } catch (error) {
+            console.warn('Falling back to default AudioContext', error);
+            this.context = new AudioContextClass();
+        }
         this.analyser = this.context.createAnalyser();
         this.analyser.fftSize = this.fftSize;
-        this.analyser.smoothingTimeConstant = 0.8;
+        this.analyser.smoothingTimeConstant = this.analysisSmoothing;
         this.frequencyData = new Float32Array(this.analyser.frequencyBinCount);
         this.timeDomainData = new Float32Array(this.analyser.fftSize);
         this.gainNode = this.context.createGain();
-        this.gainNode.gain.value = 0.8;
+        this.gainNode.gain.value = this.volumeCeiling;
         this.analyser.connect(this.gainNode);
         this.gainNode.connect(this.context.destination);
     }
@@ -144,7 +159,8 @@ export class AudioService {
 
     setVolume(value) {
         if (this.gainNode) {
-            this.gainNode.gain.value = value;
+            const clamped = Math.max(0, Math.min(this.volumeCeiling, value));
+            this.gainNode.gain.value = clamped;
         }
     }
 
@@ -154,6 +170,67 @@ export class AudioService {
 
     enableMetronome(enabled) {
         this.metronomeEnabled = enabled;
+    }
+
+    setLatencyHint(latencyHint, sampleRate) {
+        this.latencyHint = latencyHint || this.latencyHint;
+        this.targetSampleRate = sampleRate ?? this.targetSampleRate;
+        if (this.context) {
+            this.rebuildAudioGraph();
+        }
+    }
+
+    async rebuildAudioGraph() {
+        if (!this.context) return this.init();
+
+        const wasPlaying = this.isPlaying;
+        const resumeOffset = this.isPlaying
+            ? this.context.currentTime - this.startTime
+            : this.pauseTime;
+
+        this.stop();
+
+        try {
+            await this.context.close();
+        } catch (error) {
+            console.warn('Failed to close AudioContext cleanly', error);
+        }
+
+        this.context = null;
+        await this.init();
+
+        if (this.trackBuffer) {
+            this.pauseTime = resumeOffset;
+            if (wasPlaying) {
+                this.play();
+            }
+        }
+    }
+
+    setQualityPreset(preset) {
+        const presets = {
+            ultra: { fftSize: 4096, smoothing: 0.7, gain: 0.95 },
+            mobile: { fftSize: 2048, smoothing: 0.8, gain: 0.85 },
+            battery: { fftSize: 1024, smoothing: 0.9, gain: 0.75 },
+            standard: { fftSize: 2048, smoothing: 0.8, gain: 0.85 }
+        };
+
+        const config = presets[preset] || presets.standard;
+        this.qualityPreset = preset || 'standard';
+        this.fftSize = config.fftSize;
+        this.analysisSmoothing = config.smoothing;
+        this.volumeCeiling = config.gain;
+
+        if (this.analyser) {
+            this.analyser.fftSize = this.fftSize;
+            this.analyser.smoothingTimeConstant = this.analysisSmoothing;
+            this.frequencyData = new Float32Array(this.analyser.frequencyBinCount);
+            this.timeDomainData = new Float32Array(this.analyser.fftSize);
+        }
+
+        if (this.gainNode) {
+            this.setVolume(this.gainNode.gain.value);
+        }
     }
 
     onBeat(callback) {

--- a/src/game/feedback/FeedbackOrchestrator.js
+++ b/src/game/feedback/FeedbackOrchestrator.js
@@ -1,0 +1,378 @@
+/**
+ * FeedbackOrchestrator
+ * -------------------------------------------------
+ * Centralized controller that layers shared micro interactions across
+ * gameplay, audio, and UI events. Each event triggers a bundle of
+ * reusable effects so that every user input exposes richer feedback
+ * without bespoke one-off implementations.
+ */
+
+export class FeedbackOrchestrator {
+    constructor({ canvas, hud, parameterManager, audioService, gameUI } = {}) {
+        this.isReady = typeof document !== 'undefined' && typeof window !== 'undefined';
+        this.canvas = canvas;
+        this.hud = hud;
+        this.parameterManager = parameterManager;
+        this.audioService = audioService;
+        this.gameUI = gameUI;
+
+        if (!this.isReady) {
+            return;
+        }
+
+        this.container = document.getElementById('game-container');
+        this.startScreen = document.getElementById('start-screen');
+        this.pauseMenu = document.getElementById('pause-menu');
+        this.sourceButtons = Array.from(document.querySelectorAll('.source-btn'));
+        this.feedbackLayer = document.getElementById('feedback-layer');
+
+        if (!this.feedbackLayer && this.hud) {
+            this.feedbackLayer = document.createElement('div');
+            this.feedbackLayer.id = 'feedback-layer';
+            this.feedbackLayer.className = 'feedback-layer';
+            this.hud.appendChild(this.feedbackLayer);
+        }
+
+        this.elements = {
+            score: this.hud?.querySelector('.hud-score'),
+            combo: this.hud?.querySelector('.hud-combo'),
+            level: this.hud?.querySelector('.hud-level'),
+            geometry: this.hud?.querySelector('.geometry-indicator'),
+            dimensionFill: this.hud?.querySelector('.dimension-meter .meter-fill'),
+            audioBands: this.hud?.querySelector('.audio-bands'),
+            health: this.hud?.querySelector('.health-fill'),
+            pulse: this.hud?.querySelector('.pulse-fill')
+        };
+
+        this.classTimeouts = new WeakMap();
+        this.sequenceMap = this.buildSequenceMap();
+        this.effects = this.buildEffectLibrary();
+        this.beatMomentum = 0;
+        this.energyMomentum = 0;
+        this.lastBandLevels = { bass: 0, mid: 0, high: 0 };
+        this.lastAmbient = {
+            hue: this.parameterManager?.getParameter?.('hue') ?? 200
+        };
+
+        this.initializeAmbient();
+    }
+
+    initializeAmbient() {
+        if (!this.isReady) return;
+        const root = document.documentElement;
+        root.style.setProperty('--ambient-hue', `${this.lastAmbient.hue}`);
+        root.style.setProperty('--ambient-intensity', '0.55');
+        root.style.setProperty('--ambient-bass', '0.20');
+        root.style.setProperty('--ambient-mid', '0.25');
+        root.style.setProperty('--ambient-high', '0.25');
+        root.style.setProperty('--beat-intensity', '0.50');
+    }
+
+    buildSequenceMap() {
+        return {
+            beat: [
+                'bodyPulse',
+                'gridSurge',
+                'canvasRipple',
+                'hudRipple',
+                'scorePop',
+                'comboSpark',
+                'geometryTilt',
+                'meterSheen',
+                'bandBurst',
+                'spawnSpark'
+            ],
+            challenge: [
+                'challengeFocus',
+                'geometryTilt',
+                'spawnChallengeEcho',
+                'scorePop',
+                'bandBurst'
+            ],
+            state: [
+                'stateBanner',
+                'ambientRecenter',
+                'hudRipple'
+            ],
+            selection: [
+                'selectionGlow',
+                'spawnSpark'
+            ],
+            ambient: ['ambientShift']
+        };
+    }
+
+    buildEffectLibrary() {
+        return {
+            bodyPulse: ({ energy = 0.5 } = {}) => {
+                if (!this.isReady) return;
+                const intensity = Math.min(1, 0.35 + energy);
+                document.body.style.setProperty('--beat-intensity', intensity.toFixed(2));
+                this.applyClass(document.body, 'beat-flash-intense', 220);
+            },
+            gridSurge: ({ energy = 0.5 } = {}) => {
+                if (!this.isReady || !this.container) return;
+                this.container.style.setProperty('--surge-strength', (0.45 + energy * 0.6).toFixed(2));
+                this.applyClass(this.container, 'grid-surge', 360);
+            },
+            canvasRipple: ({ energy = 0.5 } = {}) => {
+                if (!this.isReady || !this.canvas) return;
+                this.canvas.style.setProperty('--ripple-scale', (0.9 + energy * 0.25).toFixed(2));
+                this.applyClass(this.canvas, 'canvas-ripple', 480);
+            },
+            hudRipple: () => {
+                if (!this.isReady || !this.hud) return;
+                this.applyClass(this.hud, 'hud-ripple', 420);
+            },
+            scorePop: ({ streak = 0 } = {}) => {
+                if (!this.isReady || !this.elements.score) return;
+                const scale = Math.min(1.5, 1 + streak * 0.04);
+                this.elements.score.style.setProperty('--streak-scale', scale.toFixed(2));
+                this.applyClass(this.elements.score, 'score-pop', 360);
+            },
+            comboSpark: ({ streak = 0 } = {}) => {
+                if (!this.isReady || !this.elements.combo) return;
+                const scale = Math.min(1.6, 1 + streak * 0.05);
+                this.elements.combo.style.setProperty('--streak-scale', scale.toFixed(2));
+                this.applyClass(this.elements.combo, 'combo-streak', 420);
+            },
+            geometryTilt: ({ energy = 0.5 } = {}) => {
+                if (!this.isReady || !this.elements.geometry) return;
+                this.elements.geometry.style.setProperty('--tilt-amount', (energy * 12).toFixed(1));
+                this.applyClass(this.elements.geometry, 'geometry-tilt', 520);
+            },
+            meterSheen: ({ mid = 0.3 } = {}) => {
+                if (!this.isReady || !this.elements.dimensionFill) return;
+                const sheen = Math.min(0.9, 0.2 + mid);
+                this.elements.dimensionFill.style.setProperty('--sheen-opacity', sheen.toFixed(2));
+                this.applyClass(this.elements.dimensionFill, 'meter-sheen', 680);
+            },
+            bandBurst: ({ high = 0.3 } = {}) => {
+                if (!this.isReady || !this.elements.audioBands) return;
+                this.elements.audioBands.style.setProperty('--band-strength', Math.min(1, high * 2).toFixed(2));
+                this.applyClass(this.elements.audioBands, 'band-burst', 260);
+            },
+            spawnSpark: ({ energy = 0.5 } = {}) => {
+                this.spawnEnergySpark(energy);
+            },
+            challengeFocus: ({ challengeType } = {}) => {
+                if (!this.isReady || !this.elements.level) return;
+                this.elements.level.dataset.challenge = challengeType || '';
+                this.applyClass(this.elements.level, 'level-focus', 560);
+            },
+            spawnChallengeEcho: ({ challengeLabel, energy = 0.5 } = {}) => {
+                this.spawnChallengeEcho(challengeLabel, energy);
+            },
+            stateBanner: ({ state } = {}) => {
+                this.stateBanner(state);
+            },
+            ambientRecenter: () => {
+                this.recenterAmbient();
+            },
+            selectionGlow: ({ sourceType } = {}) => {
+                this.highlightSource(sourceType);
+            },
+            ambientShift: ({ hue, bass, mid, high } = {}) => {
+                this.updateAmbientVariables({ hue, bass, mid, high });
+            }
+        };
+    }
+
+    applyClass(element, className, duration = 300) {
+        if (!this.isReady || !element) return;
+        if (!this.classTimeouts.has(element)) {
+            this.classTimeouts.set(element, new Map());
+        }
+
+        const perElement = this.classTimeouts.get(element);
+        if (perElement.has(className)) {
+            clearTimeout(perElement.get(className));
+        }
+
+        element.classList.add(className);
+        const timeout = setTimeout(() => {
+            element.classList.remove(className);
+            perElement.delete(className);
+        }, duration);
+        perElement.set(className, timeout);
+    }
+
+    spawnEnergySpark(strength = 0.5) {
+        if (!this.isReady || !this.feedbackLayer) return;
+        const spark = document.createElement('div');
+        spark.className = 'energy-spark';
+        const baseHue = this.parameterManager?.getParameter?.('hue') ?? this.lastAmbient.hue;
+        const hue = (baseHue + strength * 120) % 360;
+        spark.style.setProperty('--spark-hue', hue.toFixed(1));
+        spark.style.setProperty('--spark-scale', (0.6 + strength * 0.8).toFixed(2));
+        spark.style.left = `${Math.random() * 100}%`;
+        spark.style.top = `${(0.2 + Math.random() * 0.6) * 100}%`;
+        this.feedbackLayer.appendChild(spark);
+
+        setTimeout(() => {
+            spark.remove();
+        }, 900);
+    }
+
+    spawnChallengeEcho(label, strength = 0.5) {
+        if (!this.isReady || !this.feedbackLayer || !label) return;
+        const echo = document.createElement('div');
+        echo.className = 'challenge-echo';
+        echo.textContent = label;
+        echo.style.setProperty('--echo-strength', (0.45 + strength * 0.4).toFixed(2));
+        this.feedbackLayer.appendChild(echo);
+
+        if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(() => echo.classList.add('active'));
+        } else {
+            echo.classList.add('active');
+        }
+
+        setTimeout(() => {
+            echo.remove();
+        }, 1200);
+    }
+
+    stateBanner(state) {
+        if (!this.isReady) return;
+        let overlay = null;
+        if (state === 'paused') {
+            overlay = this.pauseMenu;
+        } else if (state === 'menu') {
+            overlay = this.startScreen;
+        }
+
+        if (overlay) {
+            this.applyClass(overlay, 'state-pulse', 700);
+        }
+
+        if (state === 'playing' && this.hud) {
+            this.applyClass(this.hud, 'hud-focus', 600);
+        }
+    }
+
+    highlightSource(sourceType) {
+        if (!this.isReady || !this.sourceButtons?.length) return;
+        this.sourceButtons.forEach(button => {
+            if (button.dataset.source === sourceType) {
+                this.applyClass(button, 'selection-pulse', 480);
+            }
+        });
+    }
+
+    recenterAmbient() {
+        if (!this.isReady) return;
+        const hue = this.parameterManager?.getParameter?.('hue');
+        if (typeof hue === 'number' && !Number.isNaN(hue)) {
+            this.lastAmbient.hue = hue;
+            this.updateAmbientVariables({ hue });
+        }
+    }
+
+    updateAmbientVariables({ hue, bass, mid, high } = {}) {
+        if (!this.isReady) return;
+        const root = document.documentElement;
+
+        if (typeof hue === 'number' && !Number.isNaN(hue)) {
+            this.lastAmbient.hue = ((hue % 360) + 360) % 360;
+            root.style.setProperty('--ambient-hue', this.lastAmbient.hue.toFixed(1));
+        }
+
+        if (typeof bass === 'number') {
+            root.style.setProperty('--ambient-bass', Math.min(1, Math.max(0, bass)).toFixed(2));
+        }
+        if (typeof mid === 'number') {
+            root.style.setProperty('--ambient-mid', Math.min(1, Math.max(0, mid)).toFixed(2));
+        }
+        if (typeof high === 'number') {
+            root.style.setProperty('--ambient-high', Math.min(1, Math.max(0, high)).toFixed(2));
+        }
+    }
+
+    onBeat(beatData = {}) {
+        if (!this.isReady) return;
+        if (beatData.source === 'audio') {
+            this.beatMomentum = Math.min(99, this.beatMomentum + 1);
+        } else {
+            this.beatMomentum = Math.max(0, this.beatMomentum - 2);
+        }
+
+        const context = {
+            energy: beatData.energy || 0,
+            streak: this.beatMomentum,
+            high: this.lastBandLevels.high,
+            mid: this.lastBandLevels.mid
+        };
+        this.dispatchSequence('beat', context);
+    }
+
+    onAudioFrame(audioData = {}, bandLevels = {}) {
+        if (!this.isReady) return;
+        this.energyMomentum = this.energyMomentum * 0.75 + (audioData.energy || 0) * 0.25;
+        this.lastBandLevels = {
+            bass: bandLevels.bass || 0,
+            mid: bandLevels.mid || 0,
+            high: bandLevels.high || 0
+        };
+
+        const baseHue = this.parameterManager?.getParameter?.('hue') ?? this.lastAmbient.hue;
+        const hue = (baseHue + (this.lastBandLevels.high * 90)) % 360;
+
+        this.dispatchSequence('ambient', {
+            hue,
+            bass: this.lastBandLevels.bass,
+            mid: this.lastBandLevels.mid,
+            high: this.lastBandLevels.high
+        });
+
+        if (this.elements.pulse) {
+            const ratio = Math.min(1, this.energyMomentum * 1.4);
+            this.elements.pulse.style.setProperty('--pulse-ratio', ratio.toFixed(2));
+            this.applyClass(this.elements.pulse, 'pulse-surge', 280);
+        }
+    }
+
+    onChallenge(challengeType, context = {}) {
+        if (!this.isReady) return;
+        const label = this.gameUI?.getChallengeDisplayName?.(challengeType) || challengeType;
+        this.dispatchSequence('challenge', {
+            challengeType,
+            challengeLabel: label,
+            energy: context.energy || this.lastBandLevels.mid,
+            mid: this.lastBandLevels.mid,
+            high: this.lastBandLevels.high
+        });
+    }
+
+    onStateChange(state) {
+        if (!this.isReady) return;
+        if (state === 'menu') {
+            this.beatMomentum = 0;
+        }
+        this.dispatchSequence('state', { state });
+    }
+
+    onSourceSelected(sourceType) {
+        if (!this.isReady) return;
+        this.dispatchSequence('selection', { sourceType });
+    }
+
+    update(deltaTime = 0) {
+        if (!this.isReady) return;
+        const root = document.documentElement;
+        const targetIntensity = Math.min(0.85, 0.35 + this.energyMomentum);
+        root.style.setProperty('--ambient-intensity', targetIntensity.toFixed(2));
+    }
+
+    dispatchSequence(name, context = {}) {
+        if (!this.isReady) return;
+        const sequence = this.sequenceMap[name];
+        if (!sequence) return;
+        sequence.forEach(effectName => {
+            const effect = this.effects[effectName];
+            if (typeof effect === 'function') {
+                effect(context);
+            }
+        });
+    }
+}

--- a/src/game/input/InputMapping.js
+++ b/src/game/input/InputMapping.js
@@ -173,13 +173,17 @@ export class InputMapping {
             }
         }
 
-        if (Math.abs(this.tilt.beta) > 1 || Math.abs(this.tilt.gamma) > 1) {
+        const tiltEnabled = typeof window === 'undefined' ? true : window.tiltInputEnabled !== false;
+        if (tiltEnabled && (Math.abs(this.tilt.beta) > 1 || Math.abs(this.tilt.gamma) > 1)) {
             const tiltX = this.tilt.gamma / 90;
             const tiltY = this.tilt.beta / 90;
             this.onParameterDelta?.({
                 rot4dZW: tiltX * 0.3,
                 chaos: Math.abs(tiltY) * 0.05
             });
+        } else if (!tiltEnabled) {
+            this.tilt.beta = 0;
+            this.tilt.gamma = 0;
         }
     }
 

--- a/src/game/mobile/MobileOptimizationManager.js
+++ b/src/game/mobile/MobileOptimizationManager.js
@@ -1,0 +1,305 @@
+/**
+ * MobileOptimizationManager
+ * ---------------------------------------------
+ * Dedicated orchestration layer that adapts the experience to mobile hardware.
+ * It inspects the device profile, configures rendering scale, audio analysis
+ * quality, and exposes UX hooks (graphics presets, haptics, tilt controls).
+ */
+
+export class MobileOptimizationManager {
+    constructor({ canvas, visualizer, parameterManager, audioService, startScreen, onPreferenceChanged }) {
+        this.canvas = canvas;
+        this.visualizer = visualizer;
+        this.parameterManager = parameterManager;
+        this.audioService = audioService;
+        this.startScreen = startScreen;
+        this.onPreferenceChanged = onPreferenceChanged;
+
+        this.isMobile = false;
+        this.deviceProfile = 'desktop';
+        this.graphicsProfile = 'auto';
+        this.preferredRenderScale = 1;
+        this.frameSamples = [];
+        this.hapticsEnabled = false;
+        this.tiltEnabled = true;
+        this.motionPermissionRequested = false;
+
+        this.performanceLabel = document.getElementById('mobile-performance-status');
+        this.latencyLabel = document.getElementById('latency-value');
+        this.orientationBanner = document.getElementById('orientation-warning');
+        this.graphicsButtons = Array.from(document.querySelectorAll('[data-graphics-profile]'));
+        this.hapticsButton = document.getElementById('toggle-haptics');
+        this.tiltButton = document.getElementById('toggle-tilt');
+    }
+
+    async initialize() {
+        this.detectDeviceProfile();
+        this.applyDeviceDefaults();
+        this.setupOrientationWatcher();
+        this.bindUiControls();
+    }
+
+    detectDeviceProfile() {
+        if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+            this.isMobile = false;
+            this.deviceProfile = 'desktop';
+            this.preferredRenderScale = 1;
+            return;
+        }
+
+        const ua = navigator.userAgent || '';
+        const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 1;
+        const smallestSide = Math.min(window.innerWidth, window.innerHeight);
+        this.isMobile = /Mobi|Android|iP(ad|hone|od)/i.test(ua) || (isTouch && smallestSide < 1024);
+
+        if (!this.isMobile) {
+            this.deviceProfile = 'desktop';
+            this.preferredRenderScale = 1;
+            return;
+        }
+
+        const deviceMemory = navigator.deviceMemory || 4;
+        const cores = navigator.hardwareConcurrency || 4;
+
+        if (deviceMemory >= 8 && cores >= 8) {
+            this.deviceProfile = 'flagship';
+            this.preferredRenderScale = 1.05;
+        } else if (deviceMemory >= 4 && cores >= 6) {
+            this.deviceProfile = 'performance';
+            this.preferredRenderScale = 0.9;
+        } else {
+            this.deviceProfile = 'battery';
+            this.preferredRenderScale = 0.75;
+        }
+
+        const dpr = window.devicePixelRatio || 1;
+        if (dpr > 1.5) {
+            this.preferredRenderScale /= dpr / 1.5;
+        }
+
+        this.preferredRenderScale = Math.max(0.55, Math.min(1.1, this.preferredRenderScale));
+    }
+
+    applyDeviceDefaults() {
+        if (!this.isMobile || typeof document === 'undefined') return;
+
+        document.body.classList.add('mobile-experience');
+        window.tiltInputEnabled = true;
+
+        if (this.visualizer?.setRenderScale) {
+            this.visualizer.setRenderScale(this.preferredRenderScale);
+        }
+
+        const initialProfile = this.deviceProfile === 'flagship'
+            ? 'ultra'
+            : this.deviceProfile === 'performance'
+                ? 'auto'
+                : 'battery';
+
+        this.setGraphicsProfile(initialProfile, false);
+        this.updateLatencyDisplay(this.audioService?.latencyHint || 'interactive');
+    }
+
+    bindUiControls() {
+        if (!this.isMobile) return;
+
+        this.graphicsButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                const profile = button.dataset.graphicsProfile;
+                this.setGraphicsProfile(profile);
+            });
+        });
+
+        if (this.hapticsButton) {
+            this.hapticsButton.addEventListener('click', () => {
+                this.toggleHaptics();
+            });
+        }
+
+        if (this.tiltButton) {
+            this.tiltButton.addEventListener('click', () => {
+                if (!this.motionPermissionRequested && typeof DeviceOrientationEvent !== 'undefined' &&
+                    typeof DeviceOrientationEvent.requestPermission === 'function') {
+                    DeviceOrientationEvent.requestPermission().finally(() => {
+                        this.motionPermissionRequested = true;
+                        this.toggleTilt(true);
+                    });
+                } else {
+                    this.toggleTilt();
+                }
+            });
+        }
+    }
+
+    setGraphicsProfile(profile, emitPreference = true) {
+        if (!profile) return;
+
+        this.graphicsProfile = profile;
+
+        if (!this.isMobile) {
+            if (emitPreference) {
+                this.onPreferenceChanged?.('graphicsProfile', profile);
+            }
+            return;
+        }
+
+        this.graphicsButtons.forEach(button => {
+            button.classList.toggle('active', button.dataset.graphicsProfile === profile);
+        });
+
+        let renderScale = this.preferredRenderScale;
+        let parameterOverrides = {};
+        let audioPreset = 'standard';
+
+        switch (profile) {
+            case 'ultra':
+                renderScale = Math.min(1.2, this.preferredRenderScale * 1.2);
+                parameterOverrides = {
+                    gridDensity: Math.max(this.parameterManager.getParameter('gridDensity') || 18, 24),
+                    chaos: Math.min(0.35, this.parameterManager.getParameter('chaos') || 0.2),
+                    intensity: 0.85,
+                    saturation: 0.95
+                };
+                audioPreset = 'ultra';
+                break;
+
+            case 'battery':
+                renderScale = Math.max(0.5, this.preferredRenderScale * 0.75);
+                parameterOverrides = {
+                    gridDensity: 12,
+                    chaos: 0.15,
+                    intensity: 0.5,
+                    speed: 0.9
+                };
+                audioPreset = 'battery';
+                break;
+
+            default:
+                renderScale = this.preferredRenderScale;
+                parameterOverrides = {
+                    gridDensity: 18,
+                    chaos: 0.22,
+                    intensity: 0.65,
+                    speed: 1.0
+                };
+                audioPreset = 'mobile';
+                break;
+        }
+
+        if (this.visualizer?.setRenderScale) {
+            this.visualizer.setRenderScale(renderScale);
+        }
+
+        if (this.parameterManager?.applyProfile) {
+            this.parameterManager.applyProfile(parameterOverrides);
+        }
+
+        if (this.audioService?.setQualityPreset) {
+            this.audioService.setQualityPreset(audioPreset);
+        }
+
+        this.updateLatencyDisplay(this.audioService?.latencyHint || 'interactive');
+
+        if (emitPreference) {
+            this.onPreferenceChanged?.('graphicsProfile', profile);
+        }
+    }
+
+    toggleHaptics(forceValue) {
+        const nextValue = typeof forceValue === 'boolean' ? forceValue : !this.hapticsEnabled;
+        this.hapticsEnabled = nextValue;
+
+        if (this.hapticsButton) {
+            this.hapticsButton.classList.toggle('active', this.hapticsEnabled);
+            this.hapticsButton.textContent = this.hapticsEnabled ? 'HAPTICS ✓' : 'HAPTICS';
+        }
+
+        this.onPreferenceChanged?.('hapticsEnabled', this.hapticsEnabled);
+    }
+
+    toggleTilt(forceValue) {
+        const nextValue = typeof forceValue === 'boolean' ? forceValue : !this.tiltEnabled;
+        this.tiltEnabled = nextValue;
+        window.tiltInputEnabled = this.tiltEnabled;
+
+        if (this.tiltButton) {
+            this.tiltButton.classList.toggle('active', this.tiltEnabled);
+            this.tiltButton.textContent = this.tiltEnabled ? 'TILT ✓' : 'TILT';
+        }
+
+        this.onPreferenceChanged?.('tiltEnabled', this.tiltEnabled);
+    }
+
+    recordFrame(deltaTime) {
+        if (!this.isMobile || !this.performanceLabel) return;
+
+        const fps = Math.max(0, Math.min(120, Math.round(1 / Math.max(deltaTime, 0.00001))));
+        this.frameSamples.push(fps);
+
+        if (this.frameSamples.length >= 30) {
+            const average = Math.round(this.frameSamples.reduce((sum, value) => sum + value, 0) / this.frameSamples.length);
+            this.performanceLabel.textContent = `${average} FPS`;
+            this.frameSamples = [];
+        }
+    }
+
+    handleBeat(beatData) {
+        if (!this.hapticsEnabled) return;
+        if (!navigator.vibrate) return;
+
+        const magnitude = Math.min(30, 10 + Math.round((beatData.energy || 0) * 10));
+        const pattern = beatData.source === 'audio' ? [0, magnitude] : [0, 6, 20, 6];
+        try {
+            navigator.vibrate(pattern);
+        } catch (error) {
+            console.warn('Haptic feedback failed:', error);
+        }
+    }
+
+    updateLatencyDisplay(latencyHint) {
+        if (!this.latencyLabel) return;
+        this.latencyLabel.textContent = latencyHint || 'interactive';
+    }
+
+    setupOrientationWatcher() {
+        if (!this.isMobile || !this.orientationBanner) return;
+
+        const evaluateOrientation = () => {
+            const landscape = window.innerWidth >= window.innerHeight;
+            this.orientationBanner.classList.toggle('hidden', landscape);
+        };
+
+        window.addEventListener('resize', evaluateOrientation);
+        window.addEventListener('orientationchange', evaluateOrientation);
+        evaluateOrientation();
+    }
+
+    onGameStart() {
+        if (!this.isMobile) return;
+        this.requestWakeLock();
+    }
+
+    onReturnToMenu() {
+        if (!this.isMobile) return;
+        this.releaseWakeLock();
+    }
+
+    async requestWakeLock() {
+        if (!('wakeLock' in navigator)) return;
+        try {
+            this.wakeLock = await navigator.wakeLock.request('screen');
+        } catch (error) {
+            console.warn('Wake lock unavailable:', error);
+        }
+    }
+
+    async releaseWakeLock() {
+        try {
+            await this.wakeLock?.release?.();
+        } catch (error) {
+            console.warn('Failed to release wake lock:', error);
+        }
+        this.wakeLock = null;
+    }
+}
+

--- a/src/ui/GameUI.js
+++ b/src/ui/GameUI.js
@@ -133,6 +133,7 @@ export class GameUI {
     showBeatIndicator() {
         // Visual feedback for beat detection
         document.body.classList.add('beat-flash');
+        document.body.classList.add('beat-flash-intense');
 
         if (this.beatIndicatorTimeout) {
             clearTimeout(this.beatIndicatorTimeout);
@@ -140,6 +141,7 @@ export class GameUI {
 
         this.beatIndicatorTimeout = setTimeout(() => {
             document.body.classList.remove('beat-flash');
+            document.body.classList.remove('beat-flash-intense');
         }, 150);
     }
 

--- a/styles/game.css
+++ b/styles/game.css
@@ -3,6 +3,15 @@
  * Main Game Styling
  */
 
+:root {
+    --ambient-hue: 200;
+    --ambient-intensity: 0.55;
+    --ambient-bass: 0.20;
+    --ambient-mid: 0.25;
+    --ambient-high: 0.25;
+    --beat-intensity: 0.5;
+}
+
 /* Reset and Base Styles */
 * {
     margin: 0;
@@ -12,10 +21,11 @@
 
 body {
     font-family: 'Courier New', monospace;
-    background: #000;
+    background: radial-gradient(130% 130% at 50% 50%, hsla(var(--ambient-hue), 70%, 10%, calc(var(--ambient-intensity) * 0.6)), #000 70%);
     color: #fff;
     overflow: hidden;
     user-select: none;
+    transition: background 0.35s ease, box-shadow 0.2s ease;
 }
 
 /* Game Container */
@@ -28,6 +38,38 @@ body {
     background: linear-gradient(45deg, #0a0015, #1a001a, #000030);
 }
 
+#game-container::before {
+    content: '';
+    position: absolute;
+    inset: -4%;
+    background: radial-gradient(120% 120% at 50% 50%, hsla(var(--ambient-hue), 80%, 18%, var(--ambient-intensity)), rgba(0, 0, 0, 0));
+    opacity: 0.6;
+    transition: opacity 0.35s ease, transform 0.35s ease;
+    pointer-events: none;
+}
+
+#game-container::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.04) 0px, rgba(255, 255, 255, 0.04) 1px, transparent 1px, transparent 18px),
+                repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.035) 0px, rgba(255, 255, 255, 0.035) 1px, transparent 1px, transparent 18px);
+    opacity: calc(var(--ambient-bass) * 0.4);
+    mix-blend-mode: screen;
+    transition: opacity 0.25s ease;
+    pointer-events: none;
+}
+
+#game-container.grid-surge::before {
+    opacity: var(--surge-strength, 0.95);
+    transform: scale(1.02);
+    animation: gridSurge 0.45s ease-out;
+}
+
+#game-container.grid-surge::after {
+    opacity: calc(var(--ambient-high) * 0.8 + 0.2);
+}
+
 /* Main Game Canvas */
 #game-canvas {
     position: absolute;
@@ -36,6 +78,11 @@ body {
     width: 100%;
     height: 100%;
     background: transparent;
+    transform-origin: center;
+}
+
+#game-canvas.canvas-ripple {
+    animation: canvasRipple 0.6s ease-out;
 }
 
 /* HUD System */
@@ -49,6 +96,14 @@ body {
     z-index: 10;
 }
 
+#hud.hud-ripple {
+    animation: hudRipple 0.6s ease-out;
+}
+
+#hud.hud-focus {
+    animation: hudFocus 0.6s ease-out;
+}
+
 /* HUD Top Bar */
 .hud-top {
     position: absolute;
@@ -58,6 +113,7 @@ body {
     display: flex;
     justify-content: space-between;
     padding: 0 30px;
+    z-index: 2;
 }
 
 .hud-score, .hud-combo, .hud-level {
@@ -83,6 +139,18 @@ body {
     color: #00ffff;
 }
 
+.hud-score.score-pop {
+    animation: scorePop 0.36s ease-out;
+}
+
+.hud-combo.combo-streak {
+    animation: comboStreak 0.42s ease-out;
+}
+
+.hud-level.level-focus {
+    animation: levelFocus 0.5s ease-out;
+}
+
 /* HUD Center - Geometry Display */
 .hud-center {
     position: absolute;
@@ -90,6 +158,7 @@ body {
     left: 50%;
     transform: translate(-50%, -50%);
     text-align: center;
+    z-index: 2;
 }
 
 .geometry-indicator {
@@ -105,6 +174,10 @@ body {
     transform: scale(1.2);
     color: #ffff00;
     text-shadow: 0 0 30px #ffff00;
+}
+
+.geometry-indicator.geometry-tilt {
+    animation: geometryTilt 0.55s ease-out;
 }
 
 .dimension-meter {
@@ -125,11 +198,27 @@ body {
 }
 
 .dimension-meter .meter-fill {
+    position: relative;
     height: 100%;
     background: linear-gradient(90deg, #00ffff, #ff00ff);
     width: 50%;
     transition: width 0.3s ease;
     border-radius: 4px;
+    overflow: hidden;
+}
+
+.dimension-meter .meter-fill::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.7) 50%, rgba(255, 255, 255, 0) 100%);
+    opacity: 0;
+    transform: translateX(-100%);
+}
+
+.dimension-meter .meter-fill.meter-sheen::after {
+    opacity: var(--sheen-opacity, 0.6);
+    animation: meterSheen 0.7s ease-out;
 }
 
 /* HUD Bottom Bar */
@@ -141,6 +230,7 @@ body {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    z-index: 2;
 }
 
 /* Health Bar */
@@ -176,6 +266,11 @@ body {
     transition: width 0.1s ease;
     border-radius: 4px;
     opacity: 0.8;
+    transform-origin: left;
+}
+
+.pulse-fill.pulse-surge {
+    animation: pulseSurge 0.28s ease-out;
 }
 
 /* Chaos Indicator */
@@ -207,6 +302,62 @@ body {
     gap: 5px;
     align-items: flex-end;
     height: 60px;
+    z-index: 2;
+    transform-origin: center bottom;
+}
+
+.audio-bands.band-burst {
+    animation: bandBurst 0.35s ease-out;
+}
+
+/* Feedback Layer */
+.feedback-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+    overflow: hidden;
+}
+
+.energy-spark {
+    position: absolute;
+    width: 160px;
+    height: 160px;
+    margin-left: -80px;
+    margin-top: -80px;
+    background: radial-gradient(circle, hsla(var(--spark-hue), 95%, 60%, 0.7) 0%, rgba(0, 0, 0, 0) 70%);
+    opacity: 0;
+    transform: scale(0.4);
+    animation: energySpark 0.85s ease-out forwards;
+    mix-blend-mode: screen;
+    filter: blur(0px);
+}
+
+.challenge-echo {
+    position: absolute;
+    top: 30%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(0.85);
+    padding: 10px 22px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    background: rgba(8, 8, 24, 0.8);
+    color: #fff;
+    font-size: 12px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    opacity: 0;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    pointer-events: none;
+    z-index: 3;
+}
+
+.challenge-echo.active {
+    opacity: var(--echo-strength, 0.6);
+    transform: translate(-50%, -50%) scale(1);
 }
 
 .band {
@@ -251,6 +402,10 @@ body {
 .overlay.active {
     opacity: 1;
     visibility: visible;
+}
+
+.overlay.state-pulse {
+    animation: overlayPulse 0.6s ease-out;
 }
 
 /* Start Screen */
@@ -304,6 +459,10 @@ body {
     background: #00ffff;
     color: #000;
     box-shadow: 0 0 20px #00ffff;
+}
+
+.source-btn.selection-pulse {
+    animation: selectionPulse 0.5s ease-out;
 }
 
 .primary-btn {
@@ -451,6 +610,10 @@ body.beat-flash {
     box-shadow: inset 0 0 50px rgba(0, 255, 255, 0.3);
 }
 
+body.beat-flash-intense {
+    box-shadow: inset 0 0 120px rgba(0, 255, 255, calc(var(--beat-intensity) * 0.45));
+}
+
 /* Combo Flash Animation */
 .combo-flash {
     animation: comboFlash 0.6s ease;
@@ -460,6 +623,91 @@ body.beat-flash {
     0% { transform: scale(1); color: #00ffff; }
     50% { transform: scale(1.3); color: #ffff00; text-shadow: 0 0 20px #ffff00; }
     100% { transform: scale(1); color: #00ffff; }
+}
+
+@keyframes gridSurge {
+    0% { opacity: 0.6; transform: scale(1); }
+    45% { opacity: 1; transform: scale(1.05); }
+    100% { opacity: 0.6; transform: scale(1); }
+}
+
+@keyframes canvasRipple {
+    0% { transform: scale(1); filter: drop-shadow(0 0 0 rgba(0, 255, 255, 0)); }
+    40% { transform: scale(var(--ripple-scale, 1.05)); filter: drop-shadow(0 0 30px rgba(0, 255, 255, 0.35)); }
+    100% { transform: scale(1); filter: drop-shadow(0 0 0 rgba(0, 255, 255, 0)); }
+}
+
+@keyframes hudRipple {
+    0% { filter: drop-shadow(0 0 0 rgba(0, 255, 255, 0)); }
+    50% { filter: drop-shadow(0 0 18px rgba(0, 255, 255, 0.4)); }
+    100% { filter: drop-shadow(0 0 0 rgba(0, 255, 255, 0)); }
+}
+
+@keyframes scorePop {
+    0% { transform: scale(1); box-shadow: none; }
+    40% { transform: scale(var(--streak-scale, 1.15)); box-shadow: 0 0 14px rgba(0, 255, 255, 0.4); }
+    100% { transform: scale(1); box-shadow: none; }
+}
+
+@keyframes comboStreak {
+    0% { transform: scale(1); box-shadow: none; }
+    35% { transform: scale(var(--streak-scale, 1.2)); box-shadow: 0 0 14px rgba(255, 255, 0, 0.4); }
+    100% { transform: scale(1); box-shadow: none; }
+}
+
+@keyframes levelFocus {
+    0% { transform: scale(1); color: #00ffff; }
+    45% { transform: scale(1.15); color: #ffff00; text-shadow: 0 0 14px #ffff00; }
+    100% { transform: scale(1); color: #00ffff; }
+}
+
+@keyframes geometryTilt {
+    0% { transform: rotate(0deg); }
+    40% { transform: rotate(calc(var(--tilt-amount, 6) * 1deg)); }
+    80% { transform: rotate(calc(var(--tilt-amount, 6) * -0.35deg)); }
+    100% { transform: rotate(0deg); }
+}
+
+@keyframes meterSheen {
+    0% { transform: translateX(-120%); opacity: 0; }
+    40% { transform: translateX(0%); opacity: 1; }
+    100% { transform: translateX(120%); opacity: 0; }
+}
+
+@keyframes bandBurst {
+    0% { transform: scaleY(1); filter: drop-shadow(0 0 0 rgba(0, 255, 255, 0)); }
+    45% { transform: scaleY(calc(1 + var(--band-strength, 0.3))); filter: drop-shadow(0 0 16px rgba(0, 255, 255, 0.35)); }
+    100% { transform: scaleY(1); filter: drop-shadow(0 0 0 rgba(0, 255, 255, 0)); }
+}
+
+@keyframes energySpark {
+    0% { opacity: 0; transform: scale(0.4); }
+    25% { opacity: var(--spark-scale, 0.9); transform: scale(calc(var(--spark-scale, 0.9))); }
+    60% { opacity: calc(var(--spark-scale, 0.9) * 0.7); }
+    100% { opacity: 0; transform: scale(calc(var(--spark-scale, 0.9) + 0.45)); }
+}
+
+@keyframes overlayPulse {
+    0% { box-shadow: 0 0 0 rgba(0, 255, 255, 0); transform: scale(0.97); }
+    45% { box-shadow: 0 0 25px rgba(0, 255, 255, 0.35); transform: scale(1.02); }
+    100% { box-shadow: 0 0 0 rgba(0, 255, 255, 0); transform: scale(1); }
+}
+
+@keyframes hudFocus {
+    0% { filter: saturate(0.8); opacity: 0.85; }
+    100% { filter: saturate(1.1); opacity: 1; }
+}
+
+@keyframes selectionPulse {
+    0% { box-shadow: 0 0 0 rgba(0, 255, 255, 0); transform: scale(1); }
+    40% { box-shadow: 0 0 25px rgba(0, 255, 255, 0.45); transform: scale(1.06); }
+    100% { box-shadow: 0 0 0 rgba(0, 255, 255, 0); transform: scale(1); }
+}
+
+@keyframes pulseSurge {
+    0% { opacity: 0.7; transform: scaleX(1); }
+    50% { opacity: 1; transform: scaleX(calc(1 + var(--pulse-ratio, 0.3) * 0.12)); }
+    100% { opacity: 0.75; transform: scaleX(1); }
 }
 
 /* Responsive Design */
@@ -569,4 +817,142 @@ input[type="text"]:focus {
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
+}
+
+/* Mobile Optimization Layer */
+.mobile-ux {
+    position: absolute;
+    bottom: 120px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(420px, 90vw);
+    padding: 16px;
+    border-radius: 16px;
+    background: rgba(8, 12, 32, 0.65);
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(12px);
+    display: none;
+    flex-direction: column;
+    gap: 12px;
+    z-index: 50;
+    pointer-events: auto;
+}
+
+body.mobile-experience .mobile-ux {
+    display: flex;
+}
+
+.mobile-ux .status-row,
+.mobile-ux .control-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.mobile-ux .status-chip {
+    flex: 1 1 auto;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(0, 255, 255, 0.12);
+    color: #c8f5ff;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-align: center;
+    text-transform: uppercase;
+}
+
+.mobile-ux .row-label {
+    font-size: 11px;
+    letter-spacing: 0.16em;
+    color: rgba(255, 255, 255, 0.65);
+    text-transform: uppercase;
+    min-width: 100px;
+}
+
+.mobile-ux .chip-group {
+    display: flex;
+    gap: 10px;
+    flex: 1 1 auto;
+}
+
+.mobile-ux .chip {
+    padding: 8px 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.08);
+    color: #fff;
+    font-size: 12px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    cursor: pointer;
+    pointer-events: auto;
+    transition: all 0.2s ease;
+}
+
+.mobile-ux .chip:hover {
+    border-color: rgba(0, 255, 255, 0.45);
+    box-shadow: 0 0 20px rgba(0, 255, 255, 0.25);
+}
+
+.mobile-ux .chip.active {
+    background: linear-gradient(120deg, #00ffff, #ff00ff);
+    color: #050016;
+    box-shadow: 0 0 30px rgba(0, 255, 255, 0.4);
+}
+
+.orientation-warning {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 10px 24px;
+    border-radius: 999px;
+    background: rgba(255, 196, 0, 0.9);
+    color: #120600;
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 60;
+    transition: opacity 0.3s ease;
+}
+
+body.mobile-experience .orientation-warning {
+    display: flex;
+}
+
+.orientation-warning.hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
+body.mobile-experience .orientation-warning:not(.hidden) {
+    opacity: 1;
+}
+
+.hidden {
+    display: none !important;
+}
+
+@media (max-width: 600px) {
+    .mobile-ux {
+        bottom: 96px;
+        padding: 12px;
+        gap: 10px;
+    }
+
+    .mobile-ux .row-label {
+        min-width: unset;
+        flex: 1 1 100%;
+    }
+
+    .mobile-ux .chip-group {
+        justify-content: space-between;
+    }
 }


### PR DESCRIPTION
## Summary
- introduce a reusable FeedbackOrchestrator that sequences beat, state, challenge, and selection cues across the HUD
- wire the orchestrator into the main game loop, audio handlers, and menu selection flow while adding a feedback layer to the HUD
- refresh the styling with ambient variables, spark overlays, and a library of micro-animations shared by score, combo, meter, and canvas elements

## Testing
- not run (project has no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68d39b2e866083299ec644458d3c6456