### PR TITLE
feat: orchestrate layered micro feedback across events

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ Energy → visual feedback → Timing windows
 - Safari 12+
 - Mobile browsers with WebGL support
 
+## 📱 Mobile Experience
+
+- **Adaptive Profiles**: Auto-detects device tiers (flagship, performance, battery) and tunes render scale, shader density, and audio analysis fidelity accordingly.
+- **Touch Enhancements**: On-screen control center for graphics quality, haptics, and tilt steering toggles built for thumb-friendly access.
+- **Performance Telemetry**: Live FPS and audio latency readouts help players monitor headroom while the engine auto-balances detail.
+- **Orientation Awareness**: Smart overlay guides players to rotate into hyperwide landscape when needed.
+- **Session Persistence**: Remembers last audio source, stream URL, and preferred mobile settings across launches.
+
 ## 🎵 Audio Support
 
 ### **Input Sources**

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <div id="game-container">
         <!-- Main Game Canvas -->
         <canvas id="game-canvas"></canvas>
+        <div id="feedback-overlay" class="feedback-overlay"></div>
 
         <!-- HUD Overlay -->
         <div id="hud">
@@ -55,6 +56,57 @@
                 <div class="band mid" id="mid-band"></div>
                 <div class="band high" id="high-band"></div>
             </div>
+
+            <div class="resonance-overlay">
+                <div id="beat-rings" class="beat-rings-layer"></div>
+                <div id="telegraph-grid" class="telegraph-grid"></div>
+                <div id="cadence-orbit" class="cadence-orbit">
+                    <div class="orbit-track track-bass"></div>
+                    <div class="orbit-track track-mid"></div>
+                    <div class="orbit-track track-high"></div>
+                    <div class="orbit-dot dot-bass"></div>
+                    <div class="orbit-dot dot-mid"></div>
+                    <div class="orbit-dot dot-high"></div>
+                </div>
+                <div id="burst-trails" class="burst-trails"></div>
+                <div id="momentum-meter" class="momentum-meter">
+                    <div class="label">MOMENTUM</div>
+                    <div class="meter-track">
+                        <div class="meter-fill"></div>
+                        <div class="meter-glow"></div>
+                    </div>
+                    <div class="meter-value">0%</div>
+                </div>
+                <div id="event-feed" class="event-feed"></div>
+                <div id="status-flare-layer" class="status-flare-layer"></div>
+            </div>
+        </div>
+
+        <!-- Mobile Experience Layer -->
+        <div id="mobile-ux" class="mobile-ux">
+            <div class="status-row">
+                <div class="status-chip" id="mobile-performance-status">-- FPS</div>
+                <div class="status-chip">Latency: <span id="latency-value">interactive</span></div>
+            </div>
+            <div class="control-row">
+                <span class="row-label">Graphics</span>
+                <div class="chip-group">
+                    <button class="chip active" data-graphics-profile="auto">AUTO</button>
+                    <button class="chip" data-graphics-profile="battery">BATTERY</button>
+                    <button class="chip" data-graphics-profile="ultra">ULTRA</button>
+                </div>
+            </div>
+            <div class="control-row">
+                <span class="row-label">Touch Enhancements</span>
+                <div class="chip-group">
+                    <button class="chip" id="toggle-haptics">HAPTICS</button>
+                    <button class="chip active" id="toggle-tilt">TILT ✓</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="orientation-warning" class="orientation-warning hidden">
+            <span>Rotate for Hyperwide Mode</span>
         </div>
 
         <!-- Start Screen -->

--- a/src/core/Parameters.js
+++ b/src/core/Parameters.js
@@ -88,6 +88,51 @@ export class ParameterManager {
             this.setParameter(name, value);
         }
     }
+
+    /**
+     * Apply a named or inline profile to the current parameter set.
+     * Accepts either an object with parameter overrides or a profile name.
+     */
+    applyProfile(profile) {
+        const profiles = {
+            battery: {
+                gridDensity: 12,
+                chaos: 0.15,
+                intensity: 0.5,
+                speed: 0.85
+            },
+            mobile: {
+                gridDensity: 18,
+                chaos: 0.22,
+                intensity: 0.65,
+                speed: 1.0
+            },
+            ultra: {
+                gridDensity: 26,
+                chaos: 0.3,
+                intensity: 0.85,
+                saturation: 0.95
+            }
+        };
+
+        let overrides = {};
+
+        if (typeof profile === 'string') {
+            overrides = profiles[profile] || {};
+        } else if (profile && typeof profile === 'object') {
+            overrides = profile;
+        }
+
+        if (!overrides || !Object.keys(overrides).length) {
+            return;
+        }
+
+        Object.entries(overrides).forEach(([key, value]) => {
+            if (this.parameterDefs[key]) {
+                this.setParameter(key, value);
+            }
+        });
+    }
     
     /**
      * Get a specific parameter value

--- a/src/game/feedback/FeedbackOrchestrator.js
+++ b/src/game/feedback/FeedbackOrchestrator.js
@@ -1,0 +1,667 @@
+/**
+ * FeedbackOrchestrator
+ * ---------------------
+ * Centralised layer that fans out micro interactions to every system in the
+ * game whenever a gameplay or audio event occurs. It keeps a library of small
+ * reusable effects (UI pulses, parameter impulses, audio accents, haptics,
+ * overlay telegraphs) and stitches them together so each event emits a rich
+ * packet of feedback without duplicating logic across the codebase.
+ */
+
+export class FeedbackOrchestrator {
+    constructor({ ui, visualizer, parameterManager, audioService, mobileManager } = {}) {
+        this.ui = ui;
+        this.visualizer = visualizer;
+        this.parameterManager = parameterManager;
+        this.audioService = audioService;
+        this.mobileManager = mobileManager;
+
+        this.parameterDefs = parameterManager?.parameterDefs || {};
+        this.parameterImpulses = new Map();
+        this.bandAverages = { bass: 0, mid: 0, high: 0 };
+        this.lastDominantBand = 'mid';
+        this.lastGeometry = parameterManager?.getParameter?.('geometry') ?? 1;
+
+        this.eventHandlers = this.buildEventMatrix();
+    }
+
+    setMobileManager(manager) {
+        this.mobileManager = manager;
+    }
+
+    update(deltaTime = 0) {
+        // Currently used for keeping the impulse map pruned even if audio data
+        // momentarily stalls (e.g. muted stream).
+        if (!this.parameterImpulses.size) return;
+        const now = this.now();
+        this.cleanupImpulses(now);
+    }
+
+    /**
+     * Injects any active parameter impulses into the parameter set generated
+     * by the main audio mapping logic. Called once per analyser frame to blend
+     * orchestration impulses with real-time audio responsiveness.
+     */
+    injectAudioDynamics(baseParams, context = {}) {
+        if (!baseParams) return baseParams;
+        const params = { ...baseParams };
+        const now = this.now();
+        this.cleanupImpulses(now);
+
+        this.parameterImpulses.forEach((impulses, param) => {
+            if (!(param in params)) return;
+            let totalOffset = 0;
+            impulses.forEach(impulse => {
+                const timeLeft = impulse.expiry - now;
+                if (timeLeft <= 0) return;
+                const ratio = Math.max(0, Math.min(1, timeLeft / impulse.duration));
+                const weight = this.resolveEasing(impulse.easing, ratio);
+                totalOffset += impulse.amount * weight;
+            });
+            if (totalOffset !== 0) {
+                params[param] = this.clampParameter(param, (params[param] ?? 0) + totalOffset);
+            }
+        });
+
+        if (context.bandLevels) {
+            const dominant = this.getDominantBand(context.bandLevels);
+            this.lastDominantBand = dominant;
+            const hueShiftMap = { bass: -18, mid: 12, high: 26 };
+            const hueShift = hueShiftMap[dominant] || 0;
+            if (typeof params.hue === 'number') {
+                params.hue = this.clampParameter('hue', params.hue + hueShift * (context.bandLevels[dominant] || 0));
+            }
+        }
+
+        return params;
+    }
+
+    handleAudioBands({ bass = 0, mid = 0, high = 0, energy = 0, meanEnergy = 0, momentum = 0 } = {}) {
+        this.ui?.updateCadenceOrbit({ bass, mid, high, energy });
+        const bands = { bass, mid, high };
+        Object.entries(bands).forEach(([band, value]) => {
+            const previous = this.bandAverages[band] || 0;
+            const average = previous * 0.82 + value * 0.18;
+            this.bandAverages[band] = average;
+            const delta = value - average;
+            if (delta > 0.32 && value > 0.15) {
+                this.trigger('energySpike', {
+                    band,
+                    delta,
+                    value,
+                    energy,
+                    meanEnergy,
+                    momentum
+                });
+            }
+        });
+    }
+
+    handleBeat(beatData = {}, context = {}) {
+        const { bandLevels = {}, momentum = 0, combo = 0, scoreGain = 0, level = 1, sublevel = 1 } = context;
+        const dominant = this.getDominantBand(bandLevels);
+        const intensity = this.normalizeEnergy(beatData.energy || bandLevels.energy || 0, context.meanEnergy);
+        this.trigger('beat', {
+            beatData,
+            bandLevels,
+            dominant,
+            intensity,
+            momentum,
+            combo,
+            scoreGain,
+            level,
+            sublevel,
+            geometry: this.parameterManager?.getParameter?.('geometry') ?? this.lastGeometry
+        });
+    }
+
+    handleChallenge(challenge = {}) {
+        const intensity = this.normalizeEnergy(challenge.energy || 0, challenge.meanEnergy || 0.1);
+        this.trigger('challenge', { ...challenge, intensity });
+    }
+
+    handleGeometryShift(geometry, reason = 'rotation') {
+        const names = ['TETRAHEDRON', 'HYPERCUBE', 'SPHERE', 'TORUS', 'KLEIN BOTTLE', 'FRACTAL', 'WAVE', 'CRYSTAL'];
+        const rotationSpike = (Math.random() * 0.6 + 0.4) * (Math.random() > 0.5 ? 1 : -1);
+        this.lastGeometry = geometry;
+        this.trigger('geometryShift', {
+            geometry,
+            geometryName: names[geometry] || `GEOMETRY ${geometry}`,
+            reason,
+            rotationSpike
+        });
+    }
+
+    handleComboMilestone({ combo = 0, momentum = 0, score = 0 } = {}) {
+        this.trigger('comboMilestone', { combo, momentum, score });
+    }
+
+    handleSublevelShift({ level = 1, sublevel = 1, momentum = 0 } = {}) {
+        const rotationSpike = (Math.random() * 0.4 + 0.2) * (Math.random() > 0.5 ? 1 : -1);
+        this.trigger('sublevelShift', { level, sublevel, momentum, rotationSpike });
+    }
+
+    handleDanger({ chaos = 0, health = 100, momentum = 0, reason = 'DANGER' } = {}) {
+        this.trigger('danger', { chaos, health, momentum, reason });
+    }
+
+    handleHealthShift({ amount = 0, direction = 'up', health = 0, momentum = 0, source = 'system' } = {}) {
+        const magnitude = Math.abs(amount);
+        if (!magnitude) return;
+        const intensity = Math.min(1, magnitude / 18);
+        if (direction === 'up') {
+            this.trigger('healthGain', { amount: magnitude, intensity, health, momentum, source });
+        } else {
+            this.trigger('healthLoss', { amount: magnitude, intensity, health, momentum, source });
+        }
+    }
+
+    handleComboBreak({ previousCombo = 0, combo = 0, momentum = 0, reason = 'decay' } = {}) {
+        const lost = Math.max(0, previousCombo - combo);
+        if (!lost) return;
+        const intensity = Math.min(1, lost / Math.max(5, previousCombo || 1));
+        this.trigger('comboBreak', { previousCombo, combo, lost, intensity, momentum, reason });
+    }
+
+    handleMomentumPeak({ momentum = 1, combo = 0, score = 0 } = {}) {
+        const intensity = Math.min(1, Math.max(0, momentum - 0.85) * 4);
+        if (intensity <= 0) return;
+        this.trigger('momentumPeak', { momentum, combo, score, intensity });
+    }
+
+    handleMomentumDip({ momentum = 0, previousMomentum = 0, health = 100, reason = 'decay' } = {}) {
+        const drop = Math.max(0, previousMomentum - momentum);
+        const lowFloor = momentum < 0.2 ? 0.25 : 0;
+        const intensity = Math.min(1, drop * 3 + lowFloor);
+        if (intensity <= 0.05) return;
+        this.trigger('momentumDip', { momentum, previousMomentum, health, reason, intensity });
+    }
+
+    handleScoreBurst({ scoreGain = 0, combo = 0, momentum = 0 } = {}) {
+        if (scoreGain <= 240) return;
+        const intensity = Math.min(1, scoreGain / 600);
+        this.trigger('scoreBurst', { scoreGain, combo, momentum, intensity });
+    }
+
+    handleLevelAdvance({ level = 1, score = 0 } = {}) {
+        this.trigger('levelAdvance', { level, score });
+    }
+
+    handleGameStart() {
+        this.trigger('gameStart');
+    }
+
+    handleGamePause() {
+        this.trigger('gamePause');
+    }
+
+    handleGameResume() {
+        this.trigger('gameResume');
+    }
+
+    handleGameQuit() {
+        this.trigger('gameQuit');
+    }
+
+    trigger(eventName, context = {}) {
+        const handlers = this.eventHandlers[eventName] || [];
+        handlers.forEach(handler => {
+            try {
+                handler(context);
+            } catch (error) {
+                console.warn(`Feedback handler for ${eventName} failed:`, error);
+            }
+        });
+    }
+
+    buildEventMatrix() {
+        const shared = {
+            ring: (intensity, tone = 'default') => this.ui?.spawnBeatRing?.(intensity, tone),
+            hud: (segment, variant = 'beat') => this.ui?.flashHudSegment?.(segment, variant),
+            telegraph: (pattern, duration) => this.ui?.telegraph?.(pattern, duration),
+            eventTag: (title, detail, tone) => this.ui?.pushEventTag?.(title, detail, tone),
+            momentum: value => this.ui?.updateMomentumMeter?.(value),
+            momentumPulse: (tone, duration) => this.ui?.pulseMomentumMeter?.(tone, duration),
+            overlay: (className, duration) => this.ui?.applyOverlayClass?.(className, duration),
+            haptic: (tag, intensity, extras) => this.pulseHaptics(tag, intensity, extras),
+            accent: options => this.playAccent(options),
+            parameter: (name, amount, duration, easing) => this.registerParameterImpulse(name, amount, duration, easing),
+            perfect: () => this.ui?.showPerfectHit?.(),
+            burst: (tone, intensity) => this.ui?.emitBurstTrail?.(tone, intensity),
+            flare: (label, tone, intensity) => this.ui?.flashStatusFlare?.(label, tone, intensity),
+            shake: (segment, strength) => this.ui?.shakeHudSegment?.(segment, strength)
+        };
+
+        return {
+            beat: [
+                ({ intensity, dominant }) => shared.ring?.(0.8 + intensity * 0.6, dominant),
+                () => shared.hud?.('score', 'beat'),
+                () => shared.hud?.('combo', 'beat'),
+                ({ momentum }) => shared.momentum?.(momentum),
+                ({ dominant, intensity }) => shared.eventTag?.('BEAT', `${dominant.toUpperCase()} x${(1 + intensity).toFixed(2)}`, 'beat'),
+                ({ intensity }) => shared.parameter?.('intensity', 0.18 * intensity, 340, 'decay'),
+                ({ intensity }) => shared.parameter?.('speed', 0.12 * intensity, 320, 'decay'),
+                ({ dominant, intensity }) => shared.parameter?.('hue', this.bandHueOffset(dominant, intensity), 480, 'glide'),
+                ({ intensity }) => shared.overlay?.('beat-thump', 320 + intensity * 120),
+                ({ intensity, beatData }) => shared.haptic?.('beat', intensity, { source: beatData?.source }),
+                ({ intensity }) => shared.accent?.({ tag: 'beat', intensity, duration: 0.16, sweep: 60 }),
+                ({ intensity }) => shared.burst?.('beat', intensity),
+                ({ intensity }) => shared.momentumPulse?.('beat', 380 + intensity * 180),
+                ({ intensity }) => shared.flare?.('CADENCE LOCK', 'beat', intensity),
+                ({ intensity }) => shared.shake?.('pulse', 1 + intensity * 0.6),
+                ({ beatData }) => this.visualizer?.onBeat?.(beatData)
+            ],
+            challenge: [
+                ({ type }) => this.ui?.showChallengeIndicator?.(type),
+                () => shared.hud?.('level', 'challenge'),
+                ({ band }) => shared.telegraph?.(band ? `challenge-${band}` : 'challenge', 640),
+                ({ type }) => shared.eventTag?.('CHALLENGE', type.replace(/_/g, ' ').toUpperCase(), 'challenge'),
+                ({ intensity }) => shared.parameter?.('chaos', 0.05 * intensity, 620, 'spike'),
+                ({ intensity }) => shared.parameter?.('morphFactor', 0.1 * intensity, 680, 'decay'),
+                ({ intensity }) => shared.overlay?.('challenge-surge', 500 + intensity * 200),
+                ({ intensity }) => shared.momentumPulse?.('challenge', 520 + intensity * 200),
+                ({ intensity }) => shared.haptic?.('challenge', intensity),
+                ({ intensity }) => shared.accent?.({ tag: 'challenge', intensity, duration: 0.22, type: 'triangle', sweep: -90 }),
+                ({ intensity }) => shared.burst?.('challenge', intensity),
+                ({ intensity }) => shared.flare?.('PATTERN SHIFT', 'challenge', intensity),
+                () => shared.shake?.('level', 1.2),
+                ({ intensity }) => shared.ring?.(0.7 + intensity * 0.4, 'challenge')
+            ],
+            energySpike: [
+                () => shared.hud?.('combo', 'surge'),
+                ({ band }) => shared.telegraph?.(`surge-${band}`, 420),
+                ({ band, delta }) => shared.eventTag?.('SURGE', `${band.toUpperCase()} +${Math.round(delta * 100)}%`, 'surge'),
+                ({ delta }) => shared.parameter?.('chaos', 0.04 * delta, 520, 'spike'),
+                ({ delta }) => shared.parameter?.('intensity', 0.12 * delta, 460, 'decay'),
+                ({ delta }) => shared.overlay?.('energy-surge', 400 + delta * 300),
+                ({ delta }) => shared.momentumPulse?.('surge', 420 + delta * 240),
+                ({ delta }) => shared.haptic?.('surge', delta),
+                ({ delta }) => shared.accent?.({ tag: 'surge', intensity: delta + 0.2, duration: 0.18, sweep: 140 }),
+                ({ band, delta }) => shared.ring?.(0.5 + delta, band),
+                ({ momentum, delta }) => shared.momentum?.(Math.min(1, momentum + delta * 0.6)),
+                ({ delta }) => shared.burst?.('surge', delta + 0.2),
+                ({ delta }) => shared.flare?.('ENERGY SURGE', 'surge', delta + 0.2),
+                ({ delta }) => shared.shake?.('combo', 1.1 + delta * 0.5)
+            ],
+            geometryShift: [
+                ({ geometry }) => this.ui?.updateGeometry?.(geometry),
+                () => shared.hud?.('level', 'geometry'),
+                () => shared.telegraph?.('geometry', 780),
+                ({ geometryName }) => shared.eventTag?.('GEOMETRY', geometryName, 'geometry'),
+                () => shared.parameter?.('dimension', 0.08, 820, 'glide'),
+                ({ rotationSpike }) => shared.parameter?.('rot4dXW', rotationSpike, 920, 'wave'),
+                ({ rotationSpike }) => shared.parameter?.('rot4dYW', -rotationSpike * 0.6, 920, 'wave'),
+                () => shared.overlay?.('geometry-shift', 780),
+                () => shared.haptic?.('geometry', 0.9),
+                () => shared.accent?.({ tag: 'geometry', intensity: 0.8, duration: 0.26, type: 'sawtooth', sweep: 220 }),
+                () => shared.burst?.('geometry', 0.9),
+                () => shared.flare?.('GEOMETRY SHIFT', 'geometry', 0.9),
+                () => shared.shake?.('geometry', 1.4),
+                () => shared.momentumPulse?.('geometry', 760)
+            ],
+            comboMilestone: [
+                () => shared.hud?.('combo', 'milestone'),
+                ({ combo }) => shared.eventTag?.('COMBO', `${combo}x MOMENTUM`, 'combo'),
+                ({ combo }) => shared.ring?.(1 + combo / 18, 'combo'),
+                () => shared.parameter?.('intensity', 0.15, 760, 'decay'),
+                () => shared.parameter?.('speed', 0.2, 760, 'decay'),
+                () => shared.parameter?.('chaos', -0.08, 880, 'stabilize'),
+                () => shared.overlay?.('combo-surge', 820),
+                () => shared.haptic?.('combo', 1),
+                () => shared.accent?.({ tag: 'combo', intensity: 1, duration: 0.28, type: 'square' }),
+                () => shared.perfect?.(),
+                () => shared.burst?.('combo', 1),
+                () => shared.flare?.('HYPERFLOW', 'combo', 1),
+                () => shared.momentumPulse?.('combo', 860),
+                () => shared.shake?.('combo', 1.6)
+            ],
+            danger: [
+                () => shared.hud?.('health', 'danger'),
+                ({ reason }) => shared.eventTag?.('WARNING', reason, 'danger'),
+                () => shared.telegraph?.('danger', 900),
+                () => shared.overlay?.('state-danger', 1000),
+                () => shared.parameter?.('chaos', -0.05, 1100, 'stabilize'),
+                () => shared.parameter?.('intensity', 0.12, 520, 'spike'),
+                () => shared.haptic?.('danger', 1),
+                () => shared.accent?.({ tag: 'danger', intensity: 0.7, duration: 0.32, type: 'noise' }),
+                () => shared.ring?.(1.2, 'danger'),
+                ({ momentum }) => shared.momentum?.(Math.max(0, momentum - 0.1)),
+                () => shared.burst?.('danger', 1),
+                () => shared.flare?.('HAZARD', 'danger', 1),
+                () => shared.momentumPulse?.('danger', 900),
+                () => shared.shake?.('health', 1.5)
+            ],
+            levelAdvance: [
+                ({ score, level }) => this.ui?.showLevelComplete?.(score, level),
+                () => shared.hud?.('level', 'levelup'),
+                ({ level }) => shared.eventTag?.('LEVEL UP', `LEVEL ${level}`, 'level'),
+                () => shared.parameter?.('dimension', 0.12, 1000, 'glide'),
+                () => shared.parameter?.('chaos', -0.12, 960, 'stabilize'),
+                () => shared.parameter?.('speed', 0.15, 900, 'decay'),
+                () => shared.overlay?.('level-advance', 1000),
+                () => shared.haptic?.('level', 1),
+                () => shared.accent?.({ tag: 'level', intensity: 1, duration: 0.34, type: 'triangle', sweep: 300 }),
+                () => shared.ring?.(1.4, 'level'),
+                () => shared.burst?.('level', 1),
+                () => shared.flare?.('ASCENSION', 'level', 1),
+                () => shared.momentumPulse?.('level', 920),
+                () => shared.shake?.('level', 1.4)
+            ],
+            gameStart: [
+                () => shared.eventTag?.('SESSION', 'INITIATED', 'system'),
+                () => shared.overlay?.('game-starting', 1000),
+                () => shared.parameter?.('intensity', 0.2, 1200, 'glide'),
+                () => shared.parameter?.('speed', 0.25, 1000, 'glide'),
+                () => shared.parameter?.('chaos', -0.1, 1000, 'stabilize'),
+                () => shared.haptic?.('start', 0.8),
+                () => shared.accent?.({ tag: 'start', intensity: 0.9, duration: 0.4, type: 'sawtooth', sweep: 260 }),
+                () => shared.ring?.(1.5, 'system'),
+                () => shared.hud?.('score', 'system'),
+                () => shared.hud?.('combo', 'system'),
+                () => shared.burst?.('system', 0.9),
+                () => shared.flare?.('SESSION START', 'system', 0.9),
+                () => shared.momentumPulse?.('system', 840),
+                () => shared.shake?.('score', 1.1),
+                () => shared.shake?.('combo', 1.1)
+            ],
+            gamePause: [
+                () => shared.eventTag?.('PAUSE', 'TIMESTREAM HELD', 'system'),
+                () => shared.overlay?.('game-paused', 1400),
+                () => shared.haptic?.('pause', 0.4),
+                () => shared.accent?.({ tag: 'pause', intensity: 0.3, duration: 0.2, type: 'sine' }),
+                () => shared.telegraph?.('pause', 600),
+                () => shared.parameter?.('speed', -0.3, 1500, 'hold'),
+                () => shared.parameter?.('intensity', -0.12, 1300, 'ease'),
+                () => shared.burst?.('system', 0.35),
+                () => shared.flare?.('PAUSED', 'system', 0.5),
+                () => shared.momentumPulse?.('system', 1200),
+                () => shared.hud?.('level', 'system'),
+                () => shared.shake?.('score', 0.9),
+                () => shared.shake?.('combo', 0.9)
+            ],
+            gameResume: [
+                () => shared.eventTag?.('RESUME', 'FLOW RESTORED', 'system'),
+                () => shared.overlay?.('game-resume', 900),
+                () => shared.haptic?.('resume', 0.6),
+                () => shared.accent?.({ tag: 'resume', intensity: 0.6, duration: 0.22, type: 'triangle', sweep: 120 }),
+                () => shared.parameter?.('speed', 0.2, 800, 'glide'),
+                () => shared.parameter?.('intensity', 0.08, 760, 'glide'),
+                () => shared.ring?.(1.0, 'system'),
+                () => shared.hud?.('level', 'system'),
+                () => shared.burst?.('system', 0.6),
+                () => shared.flare?.('RESUMED', 'system', 0.7),
+                () => shared.momentumPulse?.('system', 780),
+                () => shared.shake?.('score', 1.0),
+                () => shared.shake?.('combo', 1.0)
+            ],
+            gameQuit: [
+                () => shared.eventTag?.('SESSION', 'RETURN TO MENU', 'system'),
+                () => shared.overlay?.('game-quit', 900),
+                () => shared.haptic?.('quit', 0.4),
+                () => shared.accent?.({ tag: 'quit', intensity: 0.4, duration: 0.2, type: 'sine', sweep: -80 }),
+                () => shared.parameter?.('intensity', -0.15, 800, 'ease'),
+                () => shared.parameter?.('chaos', -0.05, 800, 'stabilize'),
+                () => shared.telegraph?.('system', 600),
+                () => shared.burst?.('system', 0.4),
+                () => shared.flare?.('EXITING', 'system', 0.5),
+                () => shared.momentumPulse?.('system', 720),
+                () => shared.shake?.('score', 0.9),
+                () => shared.shake?.('combo', 0.9)
+            ],
+            sublevelShift: [
+                () => shared.hud?.('level', 'sublevel'),
+                ({ level, sublevel }) => shared.eventTag?.('FLOW', `SECTOR ${level}-${sublevel}`, 'flow'),
+                ({ rotationSpike }) => shared.parameter?.('rot4dZW', rotationSpike, 720, 'wave'),
+                () => shared.telegraph?.('flow', 540),
+                () => shared.overlay?.('flow-advance', 780),
+                () => shared.accent?.({ tag: 'flow', intensity: 0.5, duration: 0.2, type: 'sawtooth', sweep: 90 }),
+                () => shared.haptic?.('flow', 0.5),
+                () => shared.burst?.('flow', 0.7),
+                () => shared.flare?.('FLOW SHIFT', 'flow', 0.8),
+                () => shared.momentumPulse?.('flow', 640),
+                () => shared.shake?.('level', 1.2),
+                () => shared.shake?.('combo', 0.8)
+            ],
+            healthGain: [
+                () => shared.hud?.('health', 'vital'),
+                ({ amount }) => shared.eventTag?.('STABILITY', `+${Math.round(amount)}`, 'vital'),
+                () => shared.telegraph?.('health-plus', 720),
+                ({ intensity }) => shared.overlay?.('health-boost', 880 + intensity * 200),
+                ({ intensity }) => shared.parameter?.('chaos', -0.06 * intensity, 820, 'stabilize'),
+                ({ intensity }) => shared.parameter?.('intensity', 0.08 * intensity, 780, 'glide'),
+                ({ intensity }) => shared.haptic?.('vital', intensity),
+                ({ intensity }) => shared.accent?.({ tag: 'vital', intensity: 0.4 + intensity * 0.6, duration: 0.32, type: 'triangle', sweep: 160 }),
+                ({ intensity }) => shared.burst?.('vital', intensity),
+                ({ intensity }) => shared.flare?.('STABILITY +', 'vital', intensity),
+                ({ intensity }) => shared.momentumPulse?.('vital', 680 + intensity * 220),
+                ({ intensity }) => shared.shake?.('health', 1 + intensity)
+            ],
+            healthLoss: [
+                () => shared.hud?.('health', 'danger'),
+                ({ amount }) => shared.eventTag?.('DAMAGE', `-${Math.round(amount)}`, 'danger'),
+                () => shared.telegraph?.('health-minus', 720),
+                ({ intensity }) => shared.overlay?.('health-loss', 900),
+                ({ intensity }) => shared.parameter?.('chaos', 0.05 * intensity, 840, 'spike'),
+                ({ intensity }) => shared.parameter?.('intensity', 0.1 * intensity, 780, 'spike'),
+                ({ intensity }) => shared.haptic?.('danger', Math.min(1, intensity + 0.2)),
+                ({ intensity }) => shared.accent?.({ tag: 'danger', intensity: 0.5 + intensity * 0.4, duration: 0.3, type: 'noise' }),
+                ({ intensity }) => shared.burst?.('danger', intensity + 0.1),
+                ({ intensity }) => shared.flare?.('VITAL DROP', 'danger', intensity + 0.1),
+                ({ momentum, intensity }) => shared.momentum?.(Math.max(0, (momentum ?? 0) - intensity * 0.2)),
+                ({ intensity }) => shared.shake?.('health', 1.4)
+            ],
+            comboBreak: [
+                () => shared.hud?.('combo', 'danger'),
+                ({ previousCombo, combo }) => shared.eventTag?.('COMBO LOST', `${previousCombo}→${combo}`, 'danger'),
+                () => shared.telegraph?.('combo-break', 780),
+                ({ intensity }) => shared.overlay?.('combo-break', 900),
+                ({ intensity }) => shared.parameter?.('chaos', 0.08 * intensity, 920, 'spike'),
+                ({ intensity }) => shared.parameter?.('speed', -0.14 * intensity, 880, 'decay'),
+                ({ intensity }) => shared.haptic?.('comboBreak', intensity),
+                ({ intensity }) => shared.accent?.({ tag: 'comboBreak', intensity: 0.6 + intensity * 0.4, duration: 0.28, type: 'square', sweep: -140 }),
+                ({ intensity }) => shared.burst?.('danger', intensity + 0.2),
+                ({ intensity }) => shared.flare?.('CHAIN BREAK', 'danger', intensity + 0.2),
+                ({ momentum, intensity }) => shared.momentum?.(Math.max(0, (momentum ?? 0) - intensity * 0.3)),
+                ({ intensity }) => shared.momentumPulse?.('danger', 820),
+                ({ intensity }) => shared.shake?.('combo', 1.8)
+            ],
+            momentumPeak: [
+                () => shared.hud?.('pulse', 'milestone'),
+                ({ momentum }) => shared.eventTag?.('MOMENTUM', `${Math.round(momentum * 100)}% PEAK`, 'momentum'),
+                () => shared.telegraph?.('momentum', 700),
+                ({ intensity }) => shared.overlay?.('momentum-peak', 880),
+                ({ intensity }) => shared.parameter?.('speed', 0.18 * intensity, 920, 'glide'),
+                ({ intensity }) => shared.parameter?.('chaos', -0.1 * intensity, 960, 'stabilize'),
+                ({ intensity }) => shared.haptic?.('momentum', intensity),
+                ({ intensity }) => shared.accent?.({ tag: 'momentum', intensity: 0.6 + intensity * 0.4, duration: 0.3, type: 'sawtooth', sweep: 200 }),
+                ({ intensity }) => shared.burst?.('momentum', intensity),
+                ({ intensity }) => shared.flare?.('MOMENTUM MAX', 'momentum', intensity),
+                ({ intensity }) => shared.momentumPulse?.('momentum', 920),
+                ({ intensity }) => shared.ring?.(1.3 + intensity * 0.2, 'momentum'),
+                ({ intensity }) => shared.shake?.('pulse', 1.5)
+            ],
+            momentumDip: [
+                () => shared.hud?.('pulse', 'danger'),
+                ({ momentum }) => shared.eventTag?.('MOMENTUM', `${Math.round(momentum * 100)}% SLIP`, 'danger'),
+                () => shared.telegraph?.('momentum-low', 720),
+                ({ intensity }) => shared.overlay?.('momentum-dip', 860),
+                ({ intensity }) => shared.parameter?.('speed', -0.12 * intensity, 820, 'decay'),
+                ({ intensity }) => shared.parameter?.('intensity', -0.1 * intensity, 780, 'ease'),
+                ({ intensity }) => shared.haptic?.('momentumDip', intensity),
+                ({ intensity }) => shared.accent?.({ tag: 'momentumDip', intensity: 0.4 + intensity * 0.4, duration: 0.26, type: 'sine', sweep: -160 }),
+                ({ intensity }) => shared.burst?.('danger', intensity),
+                ({ intensity }) => shared.flare?.('MOMENTUM DROP', 'danger', intensity),
+                ({ intensity }) => shared.momentumPulse?.('danger', 840),
+                ({ intensity }) => shared.shake?.('pulse', 1.2)
+            ],
+            scoreBurst: [
+                () => shared.hud?.('score', 'milestone'),
+                ({ scoreGain }) => {
+                    const rounded = Math.round(scoreGain);
+                    const formatted = Number.isFinite(rounded) ? rounded.toLocaleString() : `${scoreGain}`;
+                    shared.eventTag?.('SCORE BURST', `+${formatted}`, 'score');
+                },
+                () => shared.telegraph?.('score', 640),
+                ({ intensity }) => shared.overlay?.('score-burst', 840),
+                ({ intensity }) => shared.parameter?.('intensity', 0.16 * intensity, 820, 'glide'),
+                ({ intensity }) => shared.parameter?.('hue', 18 * intensity, 800, 'glide'),
+                ({ intensity }) => shared.haptic?.('score', intensity),
+                ({ intensity }) => shared.accent?.({ tag: 'score', intensity: 0.6 + intensity * 0.4, duration: 0.26, sweep: 120 }),
+                ({ intensity }) => shared.burst?.('score', intensity),
+                ({ intensity }) => shared.flare?.('SCORE +', 'score', intensity),
+                ({ intensity }) => shared.momentumPulse?.('score', 800),
+                ({ intensity }) => shared.ring?.(1.1 + intensity * 0.3, 'level'),
+                ({ intensity }) => shared.shake?.('score', 1.4)
+            ]
+        };
+    }
+
+    registerParameterImpulse(name, amount, duration = 400, easing = 'linear') {
+        if (!this.parameterManager || !name || !duration) return;
+        const now = this.now();
+        const impulses = this.parameterImpulses.get(name) || [];
+        impulses.push({ amount, duration, easing, expiry: now + duration });
+        this.parameterImpulses.set(name, impulses);
+    }
+
+    pulseHaptics(tag, intensity = 0.5, extras = {}) {
+        if (this.mobileManager?.pulseHaptics) {
+            this.mobileManager.pulseHaptics(tag, intensity, extras);
+            return;
+        }
+
+        if (typeof navigator === 'undefined' || !navigator.vibrate) return;
+        const magnitude = Math.min(40, Math.max(6, Math.round(12 + intensity * 26)));
+        let pattern;
+        switch (tag) {
+            case 'challenge':
+                pattern = [0, magnitude, 50, Math.round(magnitude * 0.6)];
+                break;
+            case 'danger':
+                pattern = [0, magnitude, 70, magnitude, 140, Math.round(magnitude * 0.7)];
+                break;
+            case 'combo':
+                pattern = [0, magnitude, 40, magnitude];
+                break;
+            case 'level':
+                pattern = [0, magnitude, 60, magnitude, 120, magnitude];
+                break;
+            default:
+                pattern = [0, magnitude];
+                break;
+        }
+        try {
+            navigator.vibrate(pattern);
+        } catch (error) {
+            console.warn('Fallback haptic vibrate failed:', error);
+        }
+    }
+
+    playAccent({ tag = 'beat', intensity = 0.6, duration = 0.18, type = 'sine', sweep = 0 } = {}) {
+        if (!this.audioService?.playTransientAccent) return;
+        const baseFrequencies = {
+            beat: 340,
+            challenge: 520,
+            surge: 620,
+            geometry: 440,
+            combo: 660,
+            danger: 220,
+            level: 760,
+            start: 480,
+            pause: 180,
+            resume: 420,
+            quit: 160,
+            flow: 540,
+            vital: 520,
+            comboBreak: 280,
+            momentum: 600,
+            momentumDip: 260,
+            score: 700
+        };
+        const frequency = baseFrequencies[tag] || 360;
+        this.audioService.playTransientAccent({
+            frequency,
+            intensity,
+            duration,
+            type,
+            sweep
+        });
+    }
+
+    bandHueOffset(band, intensity = 0) {
+        switch (band) {
+            case 'bass':
+                return -25 * (0.6 + intensity);
+            case 'mid':
+                return 18 * (0.6 + intensity);
+            case 'high':
+                return 32 * (0.5 + intensity);
+            default:
+                return 10 * intensity;
+        }
+    }
+
+    getDominantBand(bands = {}) {
+        let dominant = 'mid';
+        let maxValue = -Infinity;
+        ['bass', 'mid', 'high'].forEach(band => {
+            if ((bands[band] || 0) > maxValue) {
+                dominant = band;
+                maxValue = bands[band] || 0;
+            }
+        });
+        return dominant;
+    }
+
+    resolveEasing(easing, ratio) {
+        switch (easing) {
+            case 'decay':
+                return ratio * ratio;
+            case 'spike':
+                return Math.sin(Math.PI * ratio);
+            case 'glide':
+                return Math.pow(ratio, 0.6);
+            case 'wave':
+                return Math.sin(ratio * Math.PI * 0.5);
+            case 'stabilize':
+                return Math.pow(ratio, 1.5);
+            case 'hold':
+                return 1;
+            case 'ease':
+                return ratio;
+            default:
+                return ratio;
+        }
+    }
+
+    clampParameter(name, value) {
+        const def = this.parameterDefs[name];
+        if (!def) return value;
+        if (typeof value !== 'number') return value;
+        if (value < def.min) return def.min;
+        if (value > def.max) return def.max;
+        return value;
+    }
+
+    cleanupImpulses(now) {
+        this.parameterImpulses.forEach((impulses, key) => {
+            const active = impulses.filter(impulse => impulse.expiry > now);
+            if (active.length) {
+                this.parameterImpulses.set(key, active);
+            } else {
+                this.parameterImpulses.delete(key);
+            }
+        });
+    }
+
+    normalizeEnergy(energy = 0, mean = 0.2) {
+        const baseline = mean || 0.2;
+        if (!baseline) return energy;
+        return Math.max(0, Math.min(1.5, energy / baseline));
+    }
+
+    now() {
+        return typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now();
+    }
+}
+

--- a/src/game/input/InputMapping.js
+++ b/src/game/input/InputMapping.js
@@ -173,13 +173,17 @@ export class InputMapping {
             }
         }
 
-        if (Math.abs(this.tilt.beta) > 1 || Math.abs(this.tilt.gamma) > 1) {
+        const tiltEnabled = typeof window === 'undefined' ? true : window.tiltInputEnabled !== false;
+        if (tiltEnabled && (Math.abs(this.tilt.beta) > 1 || Math.abs(this.tilt.gamma) > 1)) {
             const tiltX = this.tilt.gamma / 90;
             const tiltY = this.tilt.beta / 90;
             this.onParameterDelta?.({
                 rot4dZW: tiltX * 0.3,
                 chaos: Math.abs(tiltY) * 0.05
             });
+        } else if (!tiltEnabled) {
+            this.tilt.beta = 0;
+            this.tilt.gamma = 0;
         }
     }
 

--- a/src/game/mobile/MobileOptimizationManager.js
+++ b/src/game/mobile/MobileOptimizationManager.js
@@ -1,0 +1,369 @@
+/**
+ * MobileOptimizationManager
+ * ---------------------------------------------
+ * Dedicated orchestration layer that adapts the experience to mobile hardware.
+ * It inspects the device profile, configures rendering scale, audio analysis
+ * quality, and exposes UX hooks (graphics presets, haptics, tilt controls).
+ */
+
+export class MobileOptimizationManager {
+    constructor({ canvas, visualizer, parameterManager, audioService, startScreen, onPreferenceChanged }) {
+        this.canvas = canvas;
+        this.visualizer = visualizer;
+        this.parameterManager = parameterManager;
+        this.audioService = audioService;
+        this.startScreen = startScreen;
+        this.onPreferenceChanged = onPreferenceChanged;
+
+        this.isMobile = false;
+        this.deviceProfile = 'desktop';
+        this.graphicsProfile = 'auto';
+        this.preferredRenderScale = 1;
+        this.frameSamples = [];
+        this.hapticsEnabled = false;
+        this.tiltEnabled = true;
+        this.motionPermissionRequested = false;
+
+        this.performanceLabel = document.getElementById('mobile-performance-status');
+        this.latencyLabel = document.getElementById('latency-value');
+        this.orientationBanner = document.getElementById('orientation-warning');
+        this.graphicsButtons = Array.from(document.querySelectorAll('[data-graphics-profile]'));
+        this.hapticsButton = document.getElementById('toggle-haptics');
+        this.tiltButton = document.getElementById('toggle-tilt');
+    }
+
+    async initialize() {
+        this.detectDeviceProfile();
+        this.applyDeviceDefaults();
+        this.setupOrientationWatcher();
+        this.bindUiControls();
+    }
+
+    detectDeviceProfile() {
+        if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+            this.isMobile = false;
+            this.deviceProfile = 'desktop';
+            this.preferredRenderScale = 1;
+            return;
+        }
+
+        const ua = navigator.userAgent || '';
+        const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 1;
+        const smallestSide = Math.min(window.innerWidth, window.innerHeight);
+        this.isMobile = /Mobi|Android|iP(ad|hone|od)/i.test(ua) || (isTouch && smallestSide < 1024);
+
+        if (!this.isMobile) {
+            this.deviceProfile = 'desktop';
+            this.preferredRenderScale = 1;
+            return;
+        }
+
+        const deviceMemory = navigator.deviceMemory || 4;
+        const cores = navigator.hardwareConcurrency || 4;
+
+        if (deviceMemory >= 8 && cores >= 8) {
+            this.deviceProfile = 'flagship';
+            this.preferredRenderScale = 1.05;
+        } else if (deviceMemory >= 4 && cores >= 6) {
+            this.deviceProfile = 'performance';
+            this.preferredRenderScale = 0.9;
+        } else {
+            this.deviceProfile = 'battery';
+            this.preferredRenderScale = 0.75;
+        }
+
+        const dpr = window.devicePixelRatio || 1;
+        if (dpr > 1.5) {
+            this.preferredRenderScale /= dpr / 1.5;
+        }
+
+        this.preferredRenderScale = Math.max(0.55, Math.min(1.1, this.preferredRenderScale));
+    }
+
+    applyDeviceDefaults() {
+        if (!this.isMobile || typeof document === 'undefined') return;
+
+        document.body.classList.add('mobile-experience');
+        window.tiltInputEnabled = true;
+
+        if (this.visualizer?.setRenderScale) {
+            this.visualizer.setRenderScale(this.preferredRenderScale);
+        }
+
+        const initialProfile = this.deviceProfile === 'flagship'
+            ? 'ultra'
+            : this.deviceProfile === 'performance'
+                ? 'auto'
+                : 'battery';
+
+        this.setGraphicsProfile(initialProfile, false);
+        this.updateLatencyDisplay(this.audioService?.latencyHint || 'interactive');
+    }
+
+    bindUiControls() {
+        if (!this.isMobile) return;
+
+        this.graphicsButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                const profile = button.dataset.graphicsProfile;
+                this.setGraphicsProfile(profile);
+            });
+        });
+
+        if (this.hapticsButton) {
+            this.hapticsButton.addEventListener('click', () => {
+                this.toggleHaptics();
+            });
+        }
+
+        if (this.tiltButton) {
+            this.tiltButton.addEventListener('click', () => {
+                if (!this.motionPermissionRequested && typeof DeviceOrientationEvent !== 'undefined' &&
+                    typeof DeviceOrientationEvent.requestPermission === 'function') {
+                    DeviceOrientationEvent.requestPermission().finally(() => {
+                        this.motionPermissionRequested = true;
+                        this.toggleTilt(true);
+                    });
+                } else {
+                    this.toggleTilt();
+                }
+            });
+        }
+    }
+
+    setGraphicsProfile(profile, emitPreference = true) {
+        if (!profile) return;
+
+        this.graphicsProfile = profile;
+
+        if (!this.isMobile) {
+            if (emitPreference) {
+                this.onPreferenceChanged?.('graphicsProfile', profile);
+            }
+            return;
+        }
+
+        this.graphicsButtons.forEach(button => {
+            button.classList.toggle('active', button.dataset.graphicsProfile === profile);
+        });
+
+        let renderScale = this.preferredRenderScale;
+        let parameterOverrides = {};
+        let audioPreset = 'standard';
+
+        switch (profile) {
+            case 'ultra':
+                renderScale = Math.min(1.2, this.preferredRenderScale * 1.2);
+                parameterOverrides = {
+                    gridDensity: Math.max(this.parameterManager.getParameter('gridDensity') || 18, 24),
+                    chaos: Math.min(0.35, this.parameterManager.getParameter('chaos') || 0.2),
+                    intensity: 0.85,
+                    saturation: 0.95
+                };
+                audioPreset = 'ultra';
+                break;
+
+            case 'battery':
+                renderScale = Math.max(0.5, this.preferredRenderScale * 0.75);
+                parameterOverrides = {
+                    gridDensity: 12,
+                    chaos: 0.15,
+                    intensity: 0.5,
+                    speed: 0.9
+                };
+                audioPreset = 'battery';
+                break;
+
+            default:
+                renderScale = this.preferredRenderScale;
+                parameterOverrides = {
+                    gridDensity: 18,
+                    chaos: 0.22,
+                    intensity: 0.65,
+                    speed: 1.0
+                };
+                audioPreset = 'mobile';
+                break;
+        }
+
+        if (this.visualizer?.setRenderScale) {
+            this.visualizer.setRenderScale(renderScale);
+        }
+
+        if (this.parameterManager?.applyProfile) {
+            this.parameterManager.applyProfile(parameterOverrides);
+        }
+
+        if (this.audioService?.setQualityPreset) {
+            this.audioService.setQualityPreset(audioPreset);
+        }
+
+        this.updateLatencyDisplay(this.audioService?.latencyHint || 'interactive');
+
+        if (emitPreference) {
+            this.onPreferenceChanged?.('graphicsProfile', profile);
+        }
+    }
+
+    toggleHaptics(forceValue) {
+        const nextValue = typeof forceValue === 'boolean' ? forceValue : !this.hapticsEnabled;
+        this.hapticsEnabled = nextValue;
+
+        if (this.hapticsButton) {
+            this.hapticsButton.classList.toggle('active', this.hapticsEnabled);
+            this.hapticsButton.textContent = this.hapticsEnabled ? 'HAPTICS ✓' : 'HAPTICS';
+        }
+
+        this.onPreferenceChanged?.('hapticsEnabled', this.hapticsEnabled);
+    }
+
+    toggleTilt(forceValue) {
+        const nextValue = typeof forceValue === 'boolean' ? forceValue : !this.tiltEnabled;
+        this.tiltEnabled = nextValue;
+        window.tiltInputEnabled = this.tiltEnabled;
+
+        if (this.tiltButton) {
+            this.tiltButton.classList.toggle('active', this.tiltEnabled);
+            this.tiltButton.textContent = this.tiltEnabled ? 'TILT ✓' : 'TILT';
+        }
+
+        this.onPreferenceChanged?.('tiltEnabled', this.tiltEnabled);
+    }
+
+    pulseHaptics(tag, intensity = 0.5, extras = {}) {
+        if (!this.hapticsEnabled) return;
+        if (typeof navigator === 'undefined' || !navigator.vibrate) return;
+
+        const magnitude = Math.min(40, Math.max(6, Math.round(12 + intensity * 28)));
+        let pattern;
+
+        switch (tag) {
+            case 'beat':
+                pattern = extras.source === 'metronome'
+                    ? [0, Math.max(6, Math.round(magnitude * 0.6))]
+                    : [0, magnitude];
+                break;
+            case 'challenge':
+                pattern = [0, magnitude, 50, Math.round(magnitude * 0.6)];
+                break;
+            case 'surge':
+                pattern = [0, magnitude, 40, Math.round(magnitude * 0.5)];
+                break;
+            case 'danger':
+                pattern = [0, magnitude, 60, magnitude, 120, Math.round(magnitude * 0.7)];
+                break;
+            case 'combo':
+                pattern = [0, magnitude, 35, magnitude, 70, Math.round(magnitude * 0.7)];
+                break;
+            case 'comboBreak':
+                pattern = [0, magnitude, 60, magnitude, 160, Math.round(magnitude * 0.9)];
+                break;
+            case 'level':
+                pattern = [0, magnitude, 50, magnitude, 100, magnitude];
+                break;
+            case 'geometry':
+                pattern = [0, magnitude, 40, Math.round(magnitude * 0.7)];
+                break;
+            case 'flow':
+                pattern = [0, magnitude, 70, Math.round(magnitude * 0.6)];
+                break;
+            case 'momentum':
+                pattern = [0, magnitude, 40, magnitude, 120, Math.round(magnitude * 0.8)];
+                break;
+            case 'momentumDip':
+                pattern = [0, Math.round(magnitude * 0.6), 70, Math.round(magnitude * 0.45)];
+                break;
+            case 'vital':
+                pattern = [0, Math.round(magnitude * 0.8), 60, Math.round(magnitude * 0.5)];
+                break;
+            case 'score':
+                pattern = [0, Math.round(magnitude * 0.7), 40, Math.round(magnitude * 0.5)];
+                break;
+            case 'start':
+                pattern = [0, magnitude, 80, Math.round(magnitude * 0.6)];
+                break;
+            case 'pause':
+                pattern = [0, Math.round(magnitude * 0.5)];
+                break;
+            case 'resume':
+                pattern = [0, magnitude, 50, Math.round(magnitude * 0.6)];
+                break;
+            case 'quit':
+                pattern = [0, Math.round(magnitude * 0.6), 60, Math.round(magnitude * 0.4)];
+                break;
+            default:
+                pattern = [0, magnitude];
+                break;
+        }
+
+        try {
+            navigator.vibrate(pattern);
+        } catch (error) {
+            console.warn('Haptic feedback failed:', error);
+        }
+    }
+
+    recordFrame(deltaTime) {
+        if (!this.isMobile || !this.performanceLabel) return;
+
+        const fps = Math.max(0, Math.min(120, Math.round(1 / Math.max(deltaTime, 0.00001))));
+        this.frameSamples.push(fps);
+
+        if (this.frameSamples.length >= 30) {
+            const average = Math.round(this.frameSamples.reduce((sum, value) => sum + value, 0) / this.frameSamples.length);
+            this.performanceLabel.textContent = `${average} FPS`;
+            this.frameSamples = [];
+        }
+    }
+
+    handleBeat(beatData) {
+        this.pulseHaptics('beat', Math.min(1, beatData?.energy || 0.5), { source: beatData?.source });
+    }
+
+    updateLatencyDisplay(latencyHint) {
+        if (!this.latencyLabel) return;
+        this.latencyLabel.textContent = latencyHint || 'interactive';
+    }
+
+    setupOrientationWatcher() {
+        if (!this.isMobile || !this.orientationBanner) return;
+
+        const evaluateOrientation = () => {
+            const landscape = window.innerWidth >= window.innerHeight;
+            this.orientationBanner.classList.toggle('hidden', landscape);
+        };
+
+        window.addEventListener('resize', evaluateOrientation);
+        window.addEventListener('orientationchange', evaluateOrientation);
+        evaluateOrientation();
+    }
+
+    onGameStart() {
+        if (!this.isMobile) return;
+        this.requestWakeLock();
+    }
+
+    onReturnToMenu() {
+        if (!this.isMobile) return;
+        this.releaseWakeLock();
+    }
+
+    async requestWakeLock() {
+        if (!('wakeLock' in navigator)) return;
+        try {
+            this.wakeLock = await navigator.wakeLock.request('screen');
+        } catch (error) {
+            console.warn('Wake lock unavailable:', error);
+        }
+    }
+
+    async releaseWakeLock() {
+        try {
+            await this.wakeLock?.release?.();
+        } catch (error) {
+            console.warn('Failed to release wake lock:', error);
+        }
+        this.wakeLock = null;
+    }
+}
+

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,8 @@ import { ParameterManager } from './core/Parameters.js';
 import { AudioService } from './game/audio/AudioService.js';
 import { GameUI } from './ui/GameUI.js';
 import { VisualizerEngine } from './core/VisualizerEngine.js';
+import { MobileOptimizationManager } from './game/mobile/MobileOptimizationManager.js';
+import { FeedbackOrchestrator } from './game/feedback/FeedbackOrchestrator.js';
 
 class VIB34DRhythmGame {
     constructor() {
@@ -24,10 +26,27 @@ class VIB34DRhythmGame {
         this.gameUI = new GameUI();
         this.visualizer = new VisualizerEngine(this.gameCanvas);
 
+        this.feedback = null;
+
         // Game state
         this.gameState = 'menu'; // menu, playing, paused, gameOver
         this.currentLevel = 1;
+        this.subLevel = 1;
+        this.levelProgress = 0;
         this.selectedAudioSource = null;
+        this.preferences = this.loadPreferences();
+        this.mobileExperience = null;
+        this.performanceSamples = [];
+        this.score = 0;
+        this.combo = 0;
+        this.maxCombo = 0;
+        this.momentum = 0;
+        this.health = 85;
+        this.comboCooldown = 0;
+        this.lastComboMilestone = 0;
+        this.dangerActive = false;
+        this.lastMeanEnergy = 0;
+        this.lastBandSnapshot = { bass: 0, mid: 0, high: 0 };
 
         this.initializeGame();
     }
@@ -41,6 +60,25 @@ class VIB34DRhythmGame {
         await this.visualizer.initialize();
         this.visualizer.setParameters(this.parameterManager.getAllParameters());
 
+        this.feedback = new FeedbackOrchestrator({
+            ui: this.gameUI,
+            visualizer: this.visualizer,
+            parameterManager: this.parameterManager,
+            audioService: this.audioService
+        });
+
+        this.mobileExperience = new MobileOptimizationManager({
+            canvas: this.gameCanvas,
+            visualizer: this.visualizer,
+            parameterManager: this.parameterManager,
+            audioService: this.audioService,
+            startScreen: this.startScreen,
+            onPreferenceChanged: (key, value) => this.updatePreference(key, value)
+        });
+        await this.mobileExperience.initialize();
+        this.feedback?.setMobileManager(this.mobileExperience);
+        this.applyMobilePreferences();
+
         console.log('VIB34D Rhythm Roguelike initialized');
     }
 
@@ -51,11 +89,14 @@ class VIB34DRhythmGame {
         // Set canvas size to match container
         const resizeCanvas = () => {
             const rect = container.getBoundingClientRect();
-            canvas.width = rect.width;
-            canvas.height = rect.height;
+            const width = rect.width;
+            const height = rect.height;
 
             if (this.visualizer) {
-                this.visualizer.handleResize(canvas.width, canvas.height);
+                this.visualizer.handleResize(width, height);
+            } else {
+                canvas.width = width;
+                canvas.height = height;
             }
         };
 
@@ -72,15 +113,9 @@ class VIB34DRhythmGame {
 
         sourceButtons.forEach(btn => {
             btn.addEventListener('click', () => {
-                this.selectAudioSource(btn.dataset.source);
-                sourceButtons.forEach(b => b.classList.remove('active'));
-                btn.classList.add('active');
-
-                // Show/hide additional inputs
-                audioFileInput.style.display = btn.dataset.source === 'file' ? 'block' : 'none';
-                streamUrlInput.style.display = btn.dataset.source === 'stream' ? 'block' : 'none';
-
-                startButton.disabled = false;
+                const sourceType = btn.dataset.source;
+                this.selectAudioSource(sourceType);
+                this.applySourceSelectionUI(sourceType, this.hasSourceData(sourceType));
             });
         });
 
@@ -88,16 +123,27 @@ class VIB34DRhythmGame {
         audioFileInput.addEventListener('change', (e) => {
             const file = e.target.files[0];
             if (file) {
-                this.selectedAudioSource = { type: 'file', data: file };
-                startButton.disabled = false;
+                this.selectAudioSource('file');
+                this.selectedAudioSource.data = file;
+                this.applySourceSelectionUI('file', true);
+            } else {
+                this.applySourceSelectionUI('file', false);
             }
         });
 
         // Stream URL handler
         streamUrlInput.addEventListener('input', (e) => {
             if (e.target.value.trim()) {
-                this.selectedAudioSource = { type: 'stream', data: e.target.value.trim() };
-                startButton.disabled = false;
+                const url = e.target.value.trim();
+                this.selectAudioSource('stream');
+                this.selectedAudioSource.data = url;
+                this.applySourceSelectionUI('stream', true);
+                this.updatePreference('lastStreamUrl', url);
+            } else {
+                this.selectAudioSource('stream');
+                this.selectedAudioSource.data = null;
+                this.applySourceSelectionUI('stream', false);
+                this.updatePreference('lastStreamUrl', '');
             }
         });
 
@@ -118,6 +164,8 @@ class VIB34DRhythmGame {
         document.getElementById('resume').addEventListener('click', () => this.resumeGame());
         document.getElementById('restart').addEventListener('click', () => this.restartLevel());
         document.getElementById('quit').addEventListener('click', () => this.quitToMenu());
+
+        this.restoreAudioPreferences();
     }
 
     setupAudioSources() {
@@ -131,12 +179,28 @@ class VIB34DRhythmGame {
         });
     }
 
-    selectAudioSource(sourceType) {
+    selectAudioSource(sourceType, persist = true) {
+        if (!sourceType) return;
         this.selectedAudioSource = { type: sourceType };
+        if (persist) {
+            this.updatePreference('lastSourceType', sourceType);
+        }
     }
 
     async startGame() {
         try {
+            if (!this.selectedAudioSource) {
+                alert('Select an audio source to begin.');
+                return;
+            }
+
+            if ((this.selectedAudioSource.type === 'file' || this.selectedAudioSource.type === 'stream') &&
+                !this.selectedAudioSource.data) {
+                alert('Provide an audio file or stream URL before starting.');
+                return;
+            }
+
+            this.resetRunState();
             this.startScreen.classList.remove('active');
             this.gameState = 'playing';
 
@@ -145,6 +209,12 @@ class VIB34DRhythmGame {
 
             // Start the game loop
             this.startGameLoop();
+
+            this.updatePreference('lastSessionTimestamp', Date.now());
+            const sessionCount = (this.preferences.sessionCount || 0) + 1;
+            this.updatePreference('sessionCount', sessionCount);
+            this.mobileExperience?.onGameStart();
+            this.feedback?.handleGameStart();
 
             console.log('Game started with audio source:', this.selectedAudioSource.type);
 
@@ -202,11 +272,18 @@ class VIB34DRhythmGame {
         // Update audio analysis
         this.audioService.update(deltaTime);
 
+        // Update internal game state metrics
+        this.updateGameState(deltaTime);
+
         // Update visualizer parameters based on audio
         this.updateVisualizerFromAudio();
 
         // Update game UI
         this.gameUI.update(deltaTime);
+
+        // Feed performance metrics to the mobile experience layer
+        this.mobileExperience?.recordFrame(deltaTime);
+        this.feedback?.update(deltaTime);
     }
 
     render() {
@@ -218,35 +295,151 @@ class VIB34DRhythmGame {
     }
 
     handleBeat(beatData) {
-        // Generate geometric challenges based on beat
-        this.generateBeatChallenge(beatData);
+        const bandLevels = this.audioService.getBandLevels();
+        const energy = beatData.energy || bandLevels.energy || 0;
+        const meanEnergy = this.lastMeanEnergy || bandLevels.energy || 0.2;
+        const normalizedEnergy = meanEnergy ? Math.max(0, Math.min(1.5, energy / meanEnergy)) : energy;
 
-        // Update UI beat indicator
+        const previousMomentum = this.momentum;
+        const previousHealth = this.health;
+
+        const baseScore = 120 + normalizedEnergy * 180;
+        const comboBonus = 1 + this.combo * 0.12;
+        const scoreGain = Math.round(baseScore * comboBonus);
+        this.score += scoreGain;
+        this.combo += 1;
+        this.maxCombo = Math.max(this.maxCombo, this.combo);
+        this.comboCooldown = 0;
+
+        const momentumBoost = 0.12 + normalizedEnergy * 0.18;
+        this.momentum = Math.min(1, this.momentum + momentumBoost);
+        if (this.momentum >= 0.92 && previousMomentum < 0.92) {
+            this.feedback?.handleMomentumPeak({
+                momentum: this.momentum,
+                combo: this.combo,
+                score: this.score
+            });
+        }
+        const healthBoost = 0.6 + normalizedEnergy * 2.0;
+        this.health = Math.min(100, this.health + healthBoost);
+        if (this.health > previousHealth + 0.2) {
+            this.feedback?.handleHealthShift({
+                amount: this.health - previousHealth,
+                direction: 'up',
+                health: this.health,
+                momentum: this.momentum,
+                source: beatData?.source || 'audio'
+            });
+        }
+
+        this.levelProgress += 0.05 + normalizedEnergy * 0.12;
+        if (this.levelProgress >= 1) {
+            this.advanceLevel();
+        } else {
+            const targetSublevel = Math.min(4, Math.floor(this.levelProgress * 4) + 1);
+            if (targetSublevel !== this.subLevel) {
+                this.subLevel = targetSublevel;
+                this.gameUI.updateLevel(this.currentLevel, this.subLevel);
+                this.feedback?.handleSublevelShift({
+                    level: this.currentLevel,
+                    sublevel: this.subLevel,
+                    momentum: this.momentum
+                });
+            }
+        }
+
+        this.gameUI.updateScore(this.score);
+        this.gameUI.updateCombo(this.combo);
+        this.gameUI.updateHealth(this.health);
+        this.gameUI.updateMomentumMeter(this.momentum);
+
+        const challenge = this.generateBeatChallenge(beatData, bandLevels);
+
+        if (normalizedEnergy > 1.1 && Math.random() > 0.65) {
+            const currentGeometry = this.parameterManager.getParameter('geometry') || 0;
+            const nextGeometry = (currentGeometry + 1) % 8;
+            this.parameterManager.setParameter('geometry', nextGeometry);
+            const params = this.parameterManager.getAllParameters();
+            this.visualizer.setParameters(params);
+            this.feedback?.handleGeometryShift(nextGeometry, 'beat-surge');
+        }
+
+        if (challenge) {
+            this.feedback?.handleChallenge({ ...challenge, band: this.feedback?.getDominantBand?.(bandLevels) });
+        }
+
         this.gameUI.showBeatIndicator();
+        this.mobileExperience?.handleBeat(beatData);
+
+        this.feedback?.handleScoreBurst({
+            scoreGain,
+            combo: this.combo,
+            momentum: this.momentum
+        });
+
+        this.feedback?.handleBeat(beatData, {
+            bandLevels,
+            intensity: normalizedEnergy,
+            momentum: this.momentum,
+            combo: this.combo,
+            scoreGain,
+            level: this.currentLevel,
+            sublevel: this.subLevel,
+            meanEnergy
+        });
+
+        const milestone = Math.floor(this.combo / 5);
+        if (milestone > this.lastComboMilestone) {
+            this.lastComboMilestone = milestone;
+            this.feedback?.handleComboMilestone({
+                combo: this.combo,
+                momentum: this.momentum,
+                score: this.score
+            });
+        }
 
         console.log('Beat detected:', beatData);
     }
 
     handleAudioData(audioData) {
-        // Use audio frequency data to modulate visualizer parameters
         const params = this.parameterManager.getAllParameters();
 
-        // Map audio bands to parameter changes
         const bassLevel = audioData.frequencyData ? this.getFrequencyRange(audioData.frequencyData, 0, 0.1) : 0;
         const midLevel = audioData.frequencyData ? this.getFrequencyRange(audioData.frequencyData, 0.1, 0.5) : 0;
         const highLevel = audioData.frequencyData ? this.getFrequencyRange(audioData.frequencyData, 0.5, 1.0) : 0;
 
-        // Update parameters based on audio analysis
-        params.gridDensity = 15 + (bassLevel * 25); // 15-40 range
-        params.chaos = Math.min(highLevel * 0.8, 1.0); // 0-0.8 range
-        params.speed = 0.8 + (midLevel * 1.2); // 0.8-2.0 range
+        params.gridDensity = 15 + (bassLevel * 25);
+        params.chaos = Math.min(highLevel * 0.8, 1.0);
+        params.speed = 0.8 + (midLevel * 1.2);
         params.hue = (params.hue + (audioData.energy || 0) * 30) % 360;
 
-        this.parameterManager.setParameters(params);
-        this.visualizer.setParameters(params);
+        const blendedParams = this.feedback
+            ? this.feedback.injectAudioDynamics(params, {
+                bandLevels: { bass: bassLevel, mid: midLevel, high: highLevel },
+                energy: audioData.energy,
+                meanEnergy: audioData.meanEnergy
+            })
+            : params;
 
-        // Update audio visualization bars in HUD
-        this.updateAudioBars(bassLevel, midLevel, highLevel);
+        this.parameterManager.setParameters(blendedParams);
+        this.visualizer.setParameters(blendedParams);
+
+        this.lastMeanEnergy = audioData.meanEnergy || 0;
+        this.lastBandSnapshot = { bass: bassLevel, mid: midLevel, high: highLevel };
+
+        this.gameUI.updateChaos(blendedParams.chaos);
+        this.gameUI.updateDimension(blendedParams.dimension);
+        this.gameUI.updateAudioBars(bassLevel, midLevel, highLevel);
+        this.gameUI.updatePulse(Math.min(1, this.momentum * 0.6 + (audioData.energy || 0) * 0.4));
+
+        this.feedback?.handleAudioBands({
+            bass: bassLevel,
+            mid: midLevel,
+            high: highLevel,
+            energy: audioData.energy || 0,
+            meanEnergy: audioData.meanEnergy || 0,
+            momentum: this.momentum
+        });
     }
 
     getFrequencyRange(frequencyData, startPercent, endPercent) {
@@ -266,13 +459,19 @@ class VIB34DRhythmGame {
         return count > 0 ? sum / count : 0;
     }
 
-    generateBeatChallenge(beatData) {
-        // Generate geometric challenge based on current parameters and beat strength
+    generateBeatChallenge(beatData, bandLevels = {}) {
         const params = this.parameterManager.getAllParameters();
         const challengeType = this.getChallengeType(params.geometry, beatData.energy);
+        const challenge = {
+            type: challengeType,
+            geometry: params.geometry,
+            energy: beatData.energy || 0,
+            meanEnergy: this.lastMeanEnergy || 0,
+            band: this.feedback?.getDominantBand?.(bandLevels)
+        };
 
-        // This will be expanded to generate specific challenges
         console.log('Generated challenge:', challengeType, 'for geometry:', params.geometry);
+        return challenge;
     }
 
     getChallengeType(geometryType, energy) {
@@ -292,26 +491,84 @@ class VIB34DRhythmGame {
     }
 
     updateHUD() {
-        // Update score, combo, level displays
-        // This will be connected to actual game state
-        document.getElementById('score').textContent = '0';
-        document.getElementById('combo').textContent = '0x';
-        document.getElementById('level').textContent = `${this.currentLevel}-1`;
-
-        // Update geometry display
-        const geometryNames = ['TETRAHEDRON', 'HYPERCUBE', 'SPHERE', 'TORUS', 'KLEIN BOTTLE', 'FRACTAL', 'WAVE', 'CRYSTAL'];
         const params = this.parameterManager.getAllParameters();
-        document.getElementById('geometry-display').textContent = geometryNames[params.geometry] || 'HYPERCUBE';
-
-        // Update dimension meter
-        const dimensionPercent = ((params.dimension - 3.0) / 1.5) * 100;
-        document.querySelector('#dimension-meter .meter-fill').style.width = `${dimensionPercent}%`;
+        this.gameUI.updateHUD({
+            params,
+            score: this.score,
+            combo: this.combo,
+            level: { level: this.currentLevel, sublevel: this.subLevel },
+            health: this.health,
+            momentum: this.momentum
+        });
     }
 
-    updateAudioBars(bass, mid, high) {
-        document.getElementById('bass-band').style.height = `${bass * 100}%`;
-        document.getElementById('mid-band').style.height = `${mid * 100}%`;
-        document.getElementById('high-band').style.height = `${high * 100}%`;
+    updateGameState(deltaTime) {
+        if (this.gameState !== 'playing') return;
+
+        this.comboCooldown += deltaTime;
+        if (this.combo > 0 && this.comboCooldown > 3.5) {
+            const previousCombo = this.combo;
+            this.combo = Math.max(0, this.combo - 1);
+            this.comboCooldown = 0;
+            this.gameUI.updateCombo(this.combo);
+            this.feedback?.handleComboBreak({
+                previousCombo,
+                combo: this.combo,
+                momentum: this.momentum,
+                reason: 'decay'
+            });
+        }
+
+        if (this.combo < this.lastComboMilestone * 5) {
+            this.lastComboMilestone = Math.floor(this.combo / 5);
+        }
+
+        const previousMomentum = this.momentum;
+        const momentumDecay = 0.05 + Math.max(0, 0.12 - (this.lastMeanEnergy || 0) * 0.08);
+        this.momentum = Math.max(0, this.momentum - momentumDecay * deltaTime);
+        if (Math.abs(this.momentum - previousMomentum) > 0.005) {
+            this.gameUI.updateMomentumMeter(this.momentum);
+        }
+        const momentumDropped = Math.max(0, previousMomentum - this.momentum);
+
+        const chaos = this.parameterManager.getParameter('chaos') || 0;
+        const previousHealth = this.health;
+        const healthDrain = Math.max(0, (chaos - 0.55) * 12 * deltaTime);
+        this.health = Math.max(0, this.health - healthDrain);
+        if (Math.abs(this.health - previousHealth) > 0.1) {
+            this.gameUI.updateHealth(this.health);
+        }
+        const lostHealth = previousHealth - this.health;
+        if (lostHealth > 0.3) {
+            this.feedback?.handleHealthShift({
+                amount: lostHealth,
+                direction: 'down',
+                health: this.health,
+                momentum: this.momentum,
+                source: 'chaos'
+            });
+        }
+        if (momentumDropped > 0.02 || (this.momentum < 0.2 && previousMomentum >= 0.2)) {
+            this.feedback?.handleMomentumDip({
+                momentum: this.momentum,
+                previousMomentum,
+                health: this.health,
+                reason: 'decay'
+            });
+        }
+
+        const dangerActive = this.health < 30 || chaos > 0.7;
+        if (dangerActive && !this.dangerActive) {
+            this.dangerActive = true;
+            this.feedback?.handleDanger({
+                chaos,
+                health: this.health,
+                momentum: this.momentum,
+                reason: this.health < 30 ? 'LOW STABILITY' : 'CHAOS SPIKE'
+            });
+        } else if (!dangerActive && this.dangerActive) {
+            this.dangerActive = false;
+        }
     }
 
     togglePause() {
@@ -326,6 +583,7 @@ class VIB34DRhythmGame {
         this.gameState = 'paused';
         this.audioService.pause();
         document.getElementById('pause-menu').classList.add('active');
+        this.feedback?.handleGamePause();
     }
 
     resumeGame() {
@@ -333,12 +591,23 @@ class VIB34DRhythmGame {
         this.audioService.play();
         document.getElementById('pause-menu').classList.remove('active');
         this.startGameLoop();
+        this.feedback?.handleGameResume();
     }
 
-    restartLevel() {
-        // Restart current level
-        this.resumeGame();
-        // Additional restart logic will be added
+    async restartLevel() {
+        try {
+            this.resetRunState();
+            this.audioService.stop();
+            await this.initializeAudio();
+            this.gameState = 'playing';
+            document.getElementById('pause-menu').classList.remove('active');
+            this.startGameLoop();
+            this.audioService.play();
+            this.mobileExperience?.onGameStart();
+            this.feedback?.handleGameStart();
+        } catch (error) {
+            console.error('Failed to restart level:', error);
+        }
     }
 
     quitToMenu() {
@@ -348,8 +617,143 @@ class VIB34DRhythmGame {
         this.startScreen.classList.add('active');
 
         // Reset game state
-        this.currentLevel = 1;
+        this.resetRunState();
         this.selectedAudioSource = null;
+        this.mobileExperience?.onReturnToMenu();
+        this.feedback?.handleGameQuit();
+    }
+
+    hasSourceData(sourceType) {
+        if (sourceType === 'mic') return true;
+        if (!this.selectedAudioSource) return false;
+        if (this.selectedAudioSource.type !== sourceType) {
+            return sourceType === 'mic';
+        }
+        return Boolean(this.selectedAudioSource.data);
+    }
+
+    applySourceSelectionUI(sourceType, hasData = false) {
+        const sourceButtons = document.querySelectorAll('.source-btn');
+        const audioFileInput = document.getElementById('audio-file');
+        const streamUrlInput = document.getElementById('stream-url');
+        const startButton = document.getElementById('start-game');
+
+        sourceButtons.forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.source === sourceType);
+        });
+
+        if (audioFileInput) {
+            audioFileInput.style.display = sourceType === 'file' ? 'block' : 'none';
+        }
+
+        if (streamUrlInput) {
+            streamUrlInput.style.display = sourceType === 'stream' ? 'block' : 'none';
+        }
+
+        if (startButton) {
+            const canStart = sourceType === 'mic' || hasData;
+            startButton.disabled = !canStart;
+        }
+    }
+
+    restoreAudioPreferences() {
+        const sourceType = this.preferences?.lastSourceType;
+        if (!sourceType) return;
+
+        if (sourceType === 'stream' && this.preferences.lastStreamUrl) {
+            const streamInput = document.getElementById('stream-url');
+            if (streamInput) {
+                streamInput.value = this.preferences.lastStreamUrl;
+            }
+            this.selectedAudioSource = { type: 'stream', data: this.preferences.lastStreamUrl };
+        }
+
+        this.selectAudioSource(sourceType, false);
+        const hasData = this.hasSourceData(sourceType);
+        this.applySourceSelectionUI(sourceType, hasData);
+    }
+
+    applyMobilePreferences() {
+        if (!this.mobileExperience || !this.preferences) return;
+
+        if (this.preferences.graphicsProfile) {
+            this.mobileExperience.setGraphicsProfile(this.preferences.graphicsProfile, false);
+        }
+
+        if (typeof this.preferences.hapticsEnabled === 'boolean') {
+            this.mobileExperience.toggleHaptics(this.preferences.hapticsEnabled);
+        }
+
+        if (typeof this.preferences.tiltEnabled === 'boolean') {
+            this.mobileExperience.toggleTilt(this.preferences.tiltEnabled);
+        }
+    }
+
+    advanceLevel() {
+        this.levelProgress = 0;
+        this.currentLevel += 1;
+        this.subLevel = 1;
+        this.gameUI.updateLevel(this.currentLevel, this.subLevel);
+        this.feedback?.handleLevelAdvance({ level: this.currentLevel, score: this.score });
+    }
+
+    resetRunState() {
+        this.score = 0;
+        this.combo = 0;
+        this.maxCombo = 0;
+        this.momentum = 0;
+        this.health = 85;
+        this.levelProgress = 0;
+        this.currentLevel = 1;
+        this.subLevel = 1;
+        this.comboCooldown = 0;
+        this.lastComboMilestone = 0;
+        this.dangerActive = false;
+        this.lastMeanEnergy = 0;
+
+        const geometry = this.parameterManager.getParameter('geometry') || 0;
+        this.gameUI.updateScore(this.score);
+        this.gameUI.updateCombo(this.combo);
+        this.gameUI.updateLevel(this.currentLevel, this.subLevel);
+        this.gameUI.updateHealth(this.health);
+        this.gameUI.updateMomentumMeter(this.momentum);
+        this.gameUI.updatePulse(0);
+        this.gameUI.updateGeometry(geometry);
+    }
+
+    loadPreferences() {
+        if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
+            return {};
+        }
+
+        try {
+            const stored = localStorage.getItem('vib34d-mobile-prefs');
+            return stored ? JSON.parse(stored) : {};
+        } catch (error) {
+            console.warn('Failed to read stored preferences', error);
+            return {};
+        }
+    }
+
+    savePreferences() {
+        if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
+            return;
+        }
+
+        try {
+            localStorage.setItem('vib34d-mobile-prefs', JSON.stringify(this.preferences));
+        } catch (error) {
+            console.warn('Failed to persist preferences', error);
+        }
+    }
+
+    updatePreference(key, value) {
+        if (!this.preferences) {
+            this.preferences = {};
+        }
+
+        this.preferences[key] = value;
+        this.savePreferences();
     }
 }
 

--- a/src/ui/GameUI.js
+++ b/src/ui/GameUI.js
@@ -1,6 +1,6 @@
 /**
  * Game UI Controller
- * Manages HUD elements and visual feedback
+ * Manages HUD elements, overlay pulses and rich feedback micro-interactions.
  */
 
 export class GameUI {
@@ -16,42 +16,79 @@ export class GameUI {
             chaos: document.getElementById('chaos'),
             bassBar: document.getElementById('bass-band'),
             midBar: document.getElementById('mid-band'),
-            highBar: document.getElementById('high-band')
+            highBar: document.getElementById('high-band'),
+            beatRings: document.getElementById('beat-rings'),
+            eventFeed: document.getElementById('event-feed'),
+            telegraphGrid: document.getElementById('telegraph-grid'),
+            momentumFill: document.querySelector('#momentum-meter .meter-fill'),
+            momentumValue: document.querySelector('#momentum-meter .meter-value'),
+            momentumGlow: document.querySelector('#momentum-meter .meter-glow'),
+            momentumMeter: document.getElementById('momentum-meter'),
+            cadenceOrbit: document.getElementById('cadence-orbit'),
+            overlay: document.getElementById('feedback-overlay'),
+            burstTrails: document.getElementById('burst-trails'),
+            statusFlares: document.getElementById('status-flare-layer')
+        };
+
+        this.elements.cadenceDots = {
+            bass: document.querySelector('#cadence-orbit .dot-bass'),
+            mid: document.querySelector('#cadence-orbit .dot-mid'),
+            high: document.querySelector('#cadence-orbit .dot-high')
+        };
+
+        this.segmentLookup = {
+            score: this.elements.score?.parentElement,
+            combo: this.elements.combo?.parentElement,
+            level: this.elements.level?.parentElement,
+            geometry: this.elements.geometryDisplay,
+            health: this.elements.health?.parentElement,
+            pulse: this.elements.pulse?.parentElement
         };
 
         this.beatIndicatorTimeout = null;
+        this.telegraphTimeout = null;
         this.animationState = {
             pulseActive: false,
             comboFlash: false
         };
+
+        this.currentScore = 0;
+        this.currentCombo = 0;
+        this.currentLevelLabel = '1-1';
+        this.currentGeometry = null;
+        this.currentDimension = 3.5;
+        this.currentMomentum = 0;
     }
 
     update(deltaTime) {
-        // Update any ongoing animations
         this.updateAnimations(deltaTime);
     }
 
     updateScore(score) {
-        if (this.elements.score) {
-            this.elements.score.textContent = score.toLocaleString();
-        }
+        if (!this.elements.score || score === this.currentScore) return;
+        this.currentScore = score;
+        this.elements.score.textContent = score.toLocaleString();
+        this.flashHudSegment('score', 'tick');
     }
 
     updateCombo(combo) {
-        if (this.elements.combo) {
-            this.elements.combo.textContent = `${combo}x`;
-
-            // Flash combo display for high combos
-            if (combo > 5 && !this.animationState.comboFlash) {
-                this.flashCombo();
-            }
+        if (!this.elements.combo || combo === this.currentCombo) return;
+        const previous = this.currentCombo;
+        this.currentCombo = combo;
+        this.elements.combo.textContent = `${combo}x`;
+        this.flashHudSegment('combo', 'tick');
+        if (combo > 5 && combo > previous) {
+            this.flashCombo();
         }
     }
 
     updateLevel(level, sublevel = 1) {
-        if (this.elements.level) {
-            this.elements.level.textContent = `${level}-${sublevel}`;
-        }
+        if (!this.elements.level) return;
+        const label = `${level}-${sublevel}`;
+        if (label === this.currentLevelLabel) return;
+        this.currentLevelLabel = label;
+        this.elements.level.textContent = label;
+        this.flashHudSegment('level', 'tick');
     }
 
     updateGeometry(geometryIndex) {
@@ -60,62 +97,55 @@ export class GameUI {
             'KLEIN BOTTLE', 'FRACTAL', 'WAVE', 'CRYSTAL'
         ];
 
-        if (this.elements.geometryDisplay) {
-            this.elements.geometryDisplay.textContent = geometryNames[geometryIndex] || 'UNKNOWN';
-            this.elements.geometryDisplay.classList.add('geometry-change');
+        if (!this.elements.geometryDisplay) return;
+        if (geometryIndex === this.currentGeometry) return;
+        this.currentGeometry = geometryIndex;
+        this.elements.geometryDisplay.textContent = geometryNames[geometryIndex] || 'UNKNOWN';
+        this.elements.geometryDisplay.classList.add('geometry-change');
 
-            setTimeout(() => {
-                this.elements.geometryDisplay.classList.remove('geometry-change');
-            }, 500);
-        }
+        setTimeout(() => {
+            this.elements.geometryDisplay?.classList.remove('geometry-change');
+        }, 500);
     }
 
     updateDimension(dimensionValue) {
-        if (this.elements.dimensionMeter) {
-            // Map dimension (3.0-4.5) to percentage (0-100%)
-            const percentage = ((dimensionValue - 3.0) / 1.5) * 100;
-            this.elements.dimensionMeter.style.width = `${Math.max(0, Math.min(100, percentage))}%`;
-
-            // Color shift based on dimension level
-            const hue = 240 + (percentage * 0.6); // Blue to purple
-            this.elements.dimensionMeter.style.backgroundColor = `hsl(${hue}, 80%, 60%)`;
-        }
+        if (!this.elements.dimensionMeter) return;
+        this.currentDimension = dimensionValue;
+        const percentage = ((dimensionValue - 3.0) / 1.5) * 100;
+        const clamped = Math.max(0, Math.min(100, percentage));
+        this.elements.dimensionMeter.style.width = `${clamped}%`;
+        const hue = 240 + (clamped * 0.6);
+        this.elements.dimensionMeter.style.backgroundColor = `hsl(${hue}, 80%, 60%)`;
     }
 
     updateHealth(healthPercent) {
-        if (this.elements.health) {
-            this.elements.health.style.width = `${Math.max(0, Math.min(100, healthPercent))}%`;
-
-            // Color health bar based on level
-            let color;
-            if (healthPercent > 60) {
-                color = '#4ade80'; // Green
-            } else if (healthPercent > 30) {
-                color = '#fbbf24'; // Yellow
-            } else {
-                color = '#ef4444'; // Red
-            }
-            this.elements.health.style.backgroundColor = color;
+        if (!this.elements.health) return;
+        const clamped = Math.max(0, Math.min(100, healthPercent));
+        this.elements.health.style.width = `${clamped}%`;
+        let color;
+        if (clamped > 60) {
+            color = '#4ade80';
+        } else if (clamped > 30) {
+            color = '#fbbf24';
+        } else {
+            color = '#ef4444';
         }
+        this.elements.health.style.backgroundColor = color;
     }
 
     updatePulse(pulseLevel) {
-        if (this.elements.pulse) {
-            this.elements.pulse.style.width = `${Math.max(0, Math.min(100, pulseLevel * 100))}%`;
-            this.animationState.pulseActive = pulseLevel > 0;
-        }
+        if (!this.elements.pulse) return;
+        const clamped = Math.max(0, Math.min(1, pulseLevel));
+        this.elements.pulse.style.width = `${clamped * 100}%`;
+        this.animationState.pulseActive = clamped > 0;
     }
 
     updateChaos(chaosLevel) {
-        if (this.elements.chaos) {
-            // Update chaos indicator with visual intensity
-            const intensity = Math.floor(chaosLevel * 10);
-            this.elements.chaos.textContent = '█'.repeat(intensity) + '░'.repeat(10 - intensity);
-
-            // Color based on chaos level
-            const hue = 120 - (chaosLevel * 120); // Green to red
-            this.elements.chaos.style.color = `hsl(${hue}, 80%, 60%)`;
-        }
+        if (!this.elements.chaos) return;
+        const intensity = Math.floor(Math.max(0, Math.min(1, chaosLevel)) * 10);
+        this.elements.chaos.textContent = '█'.repeat(intensity) + '░'.repeat(10 - intensity);
+        const hue = 120 - (chaosLevel * 120);
+        this.elements.chaos.style.color = `hsl(${hue}, 80%, 60%)`;
     }
 
     updateAudioBars(bassLevel, midLevel, highLevel) {
@@ -131,71 +161,42 @@ export class GameUI {
     }
 
     showBeatIndicator() {
-        // Visual feedback for beat detection
-        document.body.classList.add('beat-flash');
-
-        if (this.beatIndicatorTimeout) {
-            clearTimeout(this.beatIndicatorTimeout);
-        }
-
-        this.beatIndicatorTimeout = setTimeout(() => {
-            document.body.classList.remove('beat-flash');
-        }, 150);
+        this.applyOverlayClass('beat-flash', 180);
+        this.flashHudSegment('pulse', 'beat');
     }
 
     showToast(message, duration = 2000, type = 'info') {
-        // Create toast notification
         const toast = document.createElement('div');
         toast.className = `game-toast toast-${type}`;
         toast.textContent = message;
-
         document.body.appendChild(toast);
-
-        // Animate in
         setTimeout(() => toast.classList.add('active'), 10);
-
-        // Remove after duration
         setTimeout(() => {
             toast.classList.remove('active');
-            setTimeout(() => {
-                if (toast.parentNode) {
-                    toast.parentNode.removeChild(toast);
-                }
-            }, 300);
+            setTimeout(() => toast.parentNode?.removeChild(toast), 300);
         }, duration);
     }
 
     flashCombo() {
-        if (!this.elements.combo) return;
-
+        if (!this.elements.combo || this.animationState.comboFlash) return;
         this.animationState.comboFlash = true;
         this.elements.combo.classList.add('combo-flash');
-
+        this.flashHudSegment('combo', 'milestone');
         setTimeout(() => {
-            if (this.elements.combo) {
-                this.elements.combo.classList.remove('combo-flash');
-            }
+            this.elements.combo?.classList.remove('combo-flash');
             this.animationState.comboFlash = false;
         }, 600);
     }
 
     showChallengeIndicator(challengeType) {
-        // Show visual indicator for specific challenge types
         const indicator = document.createElement('div');
         indicator.className = 'challenge-indicator';
         indicator.textContent = this.getChallengeDisplayName(challengeType);
-
         document.body.appendChild(indicator);
-
         setTimeout(() => indicator.classList.add('active'), 10);
-
         setTimeout(() => {
             indicator.classList.remove('active');
-            setTimeout(() => {
-                if (indicator.parentNode) {
-                    indicator.parentNode.removeChild(indicator);
-                }
-            }, 300);
+            setTimeout(() => indicator.parentNode?.removeChild(indicator), 300);
         }, 1500);
     }
 
@@ -208,20 +209,198 @@ export class GameUI {
             dimensional_shift: '⟨4D⟩ DIMENSION SHIFT',
             morphing_adaptation: '⟐ MORPHING FLOW'
         };
-
         return challengeNames[challengeType] || challengeType.toUpperCase();
     }
 
-    updateAnimations(deltaTime) {
-        // Handle ongoing UI animations
+    updateHUD(state = {}) {
+        if (typeof state.score === 'number') {
+            this.updateScore(state.score);
+        }
+        if (typeof state.combo === 'number') {
+            this.updateCombo(state.combo);
+        }
+        if (state.level) {
+            const levelInfo = typeof state.level === 'object' ? state.level : { level: state.level, sublevel: 1 };
+            this.updateLevel(levelInfo.level, levelInfo.sublevel || 1);
+        }
+        if (state.params) {
+            if (state.params.geometry !== undefined) {
+                this.updateGeometry(state.params.geometry);
+            }
+            if (state.params.dimension !== undefined) {
+                this.updateDimension(state.params.dimension);
+            }
+            if (state.params.chaos !== undefined) {
+                this.updateChaos(state.params.chaos);
+            }
+        }
+        if (typeof state.health === 'number') {
+            this.updateHealth(state.health);
+        }
+        if (typeof state.momentum === 'number') {
+            this.updateMomentumMeter(state.momentum);
+        }
+    }
+
+    updateMomentumMeter(value) {
+        if (!this.elements.momentumFill) return;
+        const clamped = Math.max(0, Math.min(1, value));
+        this.currentMomentum = clamped;
+        this.elements.momentumFill.style.width = `${clamped * 100}%`;
+        if (this.elements.momentumValue) {
+            this.elements.momentumValue.textContent = `${Math.round(clamped * 100)}%`;
+        }
+        if (this.elements.momentumGlow) {
+            this.elements.momentumGlow.style.opacity = 0.2 + clamped * 0.6;
+        }
+    }
+
+    updateCadenceOrbit({ bass = 0, mid = 0, high = 0, energy = 0 } = {}) {
+        const orbit = this.elements.cadenceOrbit;
+        if (!orbit) return;
+        orbit.style.setProperty('--bass-strength', bass);
+        orbit.style.setProperty('--mid-strength', mid);
+        orbit.style.setProperty('--high-strength', high);
+        orbit.style.setProperty('--bass-duration', `${Math.max(1.2, 4 - bass * 2.5)}s`);
+        orbit.style.setProperty('--mid-duration', `${Math.max(1, 3.6 - mid * 2.2)}s`);
+        orbit.style.setProperty('--high-duration', `${Math.max(0.8, 3.2 - high * 2.0)}s`);
+        orbit.style.opacity = Math.min(1, Math.max(bass, mid, high) * 1.2);
+
+        if (this.elements.cadenceDots.bass) {
+            this.elements.cadenceDots.bass.style.transform = `scale(${0.6 + bass * 0.8})`;
+        }
+        if (this.elements.cadenceDots.mid) {
+            this.elements.cadenceDots.mid.style.transform = `scale(${0.6 + mid * 0.8})`;
+        }
+        if (this.elements.cadenceDots.high) {
+            this.elements.cadenceDots.high.style.transform = `scale(${0.6 + high * 0.8})`;
+        }
+    }
+
+    flashHudSegment(segment, variant = 'beat') {
+        const target = this.segmentLookup[segment];
+        if (!target) return;
+        const className = `hud-flash-${variant}`;
+        target.classList.add(className);
+        setTimeout(() => target.classList.remove(className), 420);
+    }
+
+    shakeHudSegment(segment, strength = 1) {
+        const target = this.segmentLookup[segment];
+        if (!target) return;
+        const className = strength > 1 ? 'hud-shake-strong' : 'hud-shake';
+        target.classList.add(className);
+        const duration = strength > 1 ? 720 : 420;
+        setTimeout(() => target.classList.remove(className), duration);
+    }
+
+    pulseMomentumMeter(tone = 'info', duration = 600) {
+        const meter = this.elements.momentumMeter;
+        if (!meter) return;
+        const className = `momentum-pulse-${tone}`;
+        meter.style.setProperty('--momentum-pulse-duration', `${duration}ms`);
+        meter.classList.add(className);
+        setTimeout(() => meter.classList.remove(className), duration);
+        setTimeout(() => meter.style.removeProperty('--momentum-pulse-duration'), duration + 50);
+    }
+
+    emitBurstTrail(tone = 'info', intensity = 0.6) {
+        const container = this.elements.burstTrails;
+        if (!container) return;
+        const burst = document.createElement('div');
+        burst.className = `burst-trail tone-${tone}`;
+        const offsetX = (Math.random() * 60 - 30).toFixed(1);
+        const offsetY = (Math.random() * 50 - 25).toFixed(1);
+        const duration = 600 + Math.round(intensity * 320);
+        burst.style.setProperty('--burst-offset-x', `${offsetX}px`);
+        burst.style.setProperty('--burst-offset-y', `${offsetY}px`);
+        burst.style.setProperty('--burst-scale', (0.8 + intensity * 0.9).toFixed(2));
+        burst.style.setProperty('--burst-duration', `${duration}ms`);
+        container.appendChild(burst);
+        requestAnimationFrame(() => burst.classList.add('active'));
+        setTimeout(() => burst.parentNode?.removeChild(burst), duration + 240);
+    }
+
+    flashStatusFlare(label, tone = 'info', intensity = 0.5) {
+        const layer = this.elements.statusFlares;
+        if (!layer || !label) return;
+        const flare = document.createElement('div');
+        flare.className = `status-flare tone-${tone}`;
+        flare.style.setProperty('--flare-scale', (0.75 + intensity * 0.95).toFixed(2));
+        flare.innerHTML = `<span class="status-flare-label">${label}</span>`;
+        layer.appendChild(flare);
+        requestAnimationFrame(() => flare.classList.add('active'));
+        const lifetime = 900 + Math.round(intensity * 520);
+        setTimeout(() => {
+            flare.classList.remove('active');
+            setTimeout(() => flare.parentNode?.removeChild(flare), 280);
+        }, lifetime);
+    }
+
+    spawnBeatRing(intensity = 1, tone = 'default') {
+        const layer = this.elements.beatRings;
+        if (!layer) return;
+        const ring = document.createElement('div');
+        ring.className = `beat-ring tone-${tone || 'default'}`;
+        ring.style.setProperty('--ring-scale', (0.6 + intensity * 0.6).toFixed(2));
+        ring.style.setProperty('--ring-intensity', Math.min(1, 0.4 + intensity * 0.6));
+        layer.appendChild(ring);
+        requestAnimationFrame(() => ring.classList.add('active'));
+        setTimeout(() => ring.parentNode?.removeChild(ring), 720);
+    }
+
+    telegraph(pattern, duration = 600) {
+        const grid = this.elements.telegraphGrid;
+        if (!grid) return;
+        grid.className = 'telegraph-grid';
+        if (!pattern) return;
+        grid.classList.add('active');
+        grid.classList.add(`pattern-${pattern}`);
+        if (this.telegraphTimeout) {
+            clearTimeout(this.telegraphTimeout);
+        }
+        this.telegraphTimeout = setTimeout(() => {
+            grid.classList.remove('active');
+            grid.classList.remove(`pattern-${pattern}`);
+        }, duration);
+    }
+
+    pushEventTag(title, detail, tone = 'info') {
+        const feed = this.elements.eventFeed;
+        if (!feed) return;
+        const tag = document.createElement('div');
+        tag.className = `event-tag tone-${tone}`;
+        tag.innerHTML = `
+            <span class="event-tag-title">${title}</span>
+            <span class="event-tag-detail">${detail}</span>
+        `;
+        feed.prepend(tag);
+        requestAnimationFrame(() => tag.classList.add('active'));
+        while (feed.children.length > 6) {
+            feed.removeChild(feed.lastChild);
+        }
+        setTimeout(() => {
+            tag.classList.remove('active');
+            setTimeout(() => tag.parentNode?.removeChild(tag), 400);
+        }, 2600);
+    }
+
+    applyOverlayClass(className, duration = 400) {
+        const overlay = this.elements.overlay;
+        if (!overlay || !className) return;
+        overlay.classList.add(className);
+        if (duration > 0) {
+            setTimeout(() => overlay.classList.remove(className), duration);
+        }
+    }
+
+    updateAnimations() {
         if (this.animationState.pulseActive && this.elements.pulse) {
-            // Pulse animation effect
             const pulseOpacity = 0.7 + 0.3 * Math.sin(Date.now() * 0.01);
             this.elements.pulse.style.opacity = pulseOpacity;
         }
     }
 
-    // Game state methods
     showGameOver(score, level) {
         this.showToast(`GAME OVER - Score: ${score.toLocaleString()} - Level: ${level}`, 5000, 'error');
     }
@@ -234,37 +413,48 @@ export class GameUI {
     }
 
     showPerfectHit() {
-        // Special effect for perfect timing
         const perfect = document.createElement('div');
         perfect.className = 'perfect-hit';
         perfect.textContent = 'PERFECT!';
-
         document.body.appendChild(perfect);
-
         setTimeout(() => perfect.classList.add('active'), 10);
-
         setTimeout(() => {
             perfect.classList.remove('active');
-            setTimeout(() => {
-                if (perfect.parentNode) {
-                    perfect.parentNode.removeChild(perfect);
-                }
-            }, 500);
+            setTimeout(() => perfect.parentNode?.removeChild(perfect), 500);
         }, 1000);
     }
 
-    // Cleanup method
     cleanup() {
         if (this.beatIndicatorTimeout) {
             clearTimeout(this.beatIndicatorTimeout);
+            this.beatIndicatorTimeout = null;
         }
-
-        // Remove any lingering toast messages
+        if (this.telegraphTimeout) {
+            clearTimeout(this.telegraphTimeout);
+            this.telegraphTimeout = null;
+        }
         const toasts = document.querySelectorAll('.game-toast, .challenge-indicator, .perfect-hit');
-        toasts.forEach(toast => {
-            if (toast.parentNode) {
-                toast.parentNode.removeChild(toast);
-            }
-        });
+        toasts.forEach(node => node.parentNode?.removeChild(node));
+        if (this.elements.eventFeed) {
+            this.elements.eventFeed.innerHTML = '';
+        }
+        if (this.elements.beatRings) {
+            this.elements.beatRings.innerHTML = '';
+        }
+        if (this.elements.overlay) {
+            this.elements.overlay.className = 'feedback-overlay';
+        }
+        if (this.elements.burstTrails) {
+            this.elements.burstTrails.innerHTML = '';
+        }
+        if (this.elements.statusFlares) {
+            this.elements.statusFlares.innerHTML = '';
+        }
+        if (this.elements.momentumMeter) {
+            Array.from(this.elements.momentumMeter.classList)
+                .filter(cls => cls.startsWith('momentum-pulse-'))
+                .forEach(cls => this.elements.momentumMeter.classList.remove(cls));
+            this.elements.momentumMeter.style.removeProperty('--momentum-pulse-duration');
+        }
     }
 }

--- a/styles/game.css
+++ b/styles/game.css
@@ -229,6 +229,730 @@ body {
     background: linear-gradient(to top, #8000ff, #c080ff);
 }
 
+/* Resonance Overlay & Feedback */
+.feedback-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 5;
+    mix-blend-mode: screen;
+}
+
+.feedback-overlay::before,
+.feedback-overlay::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+}
+
+.feedback-overlay.beat-flash::before {
+    background: radial-gradient(circle at center, rgba(0, 255, 255, 0.45), transparent 70%);
+    animation: overlayPulse 0.22s ease-out forwards;
+}
+
+.feedback-overlay.beat-thump::before {
+    background: radial-gradient(circle at center, rgba(0, 180, 255, 0.35), transparent 80%);
+    animation: overlayPulse 0.4s ease-out forwards;
+}
+
+.feedback-overlay.challenge-surge::before {
+    background: radial-gradient(circle at center, rgba(255, 0, 128, 0.35), transparent 70%);
+    animation: overlaySweep 0.52s ease-out forwards;
+}
+
+.feedback-overlay.energy-surge::before {
+    background: radial-gradient(circle at center, rgba(255, 196, 0, 0.28), transparent 75%);
+    animation: overlaySweep 0.45s ease-out forwards;
+}
+
+.feedback-overlay.geometry-shift::before {
+    background: radial-gradient(circle at center, rgba(128, 255, 255, 0.32), transparent 80%);
+    animation: overlayGlide 0.6s ease-in-out forwards;
+}
+
+.feedback-overlay.combo-surge::before {
+    background: radial-gradient(circle at center, rgba(255, 80, 220, 0.4), transparent 70%);
+    animation: overlayPulse 0.5s ease-out forwards;
+}
+
+.feedback-overlay.state-danger::before {
+    background: radial-gradient(circle at center, rgba(255, 56, 56, 0.35), transparent 85%);
+    animation: overlayPulse 0.9s ease-out forwards;
+}
+
+.feedback-overlay.level-advance::before {
+    background: radial-gradient(circle at center, rgba(120, 255, 180, 0.38), transparent 75%);
+    animation: overlayGlide 0.7s ease-out forwards;
+}
+
+.feedback-overlay.game-starting::before {
+    background: radial-gradient(circle at center, rgba(128, 255, 255, 0.35), transparent 65%);
+    animation: overlaySweep 0.8s ease-out forwards;
+}
+
+.feedback-overlay.game-paused::before {
+    background: rgba(10, 14, 40, 0.45);
+    backdrop-filter: blur(6px);
+    opacity: 1;
+}
+
+.feedback-overlay.game-resume::before {
+    background: radial-gradient(circle at center, rgba(64, 255, 180, 0.3), transparent 75%);
+    animation: overlayPulse 0.45s ease-out forwards;
+}
+
+.feedback-overlay.game-quit::before {
+    background: radial-gradient(circle at center, rgba(40, 60, 120, 0.4), transparent 80%);
+    animation: overlayGlide 0.5s ease-out forwards;
+}
+
+.feedback-overlay.flow-advance::before {
+    background: radial-gradient(circle at center, rgba(120, 180, 255, 0.32), transparent 75%);
+    animation: overlaySweep 0.6s ease-out forwards;
+}
+
+.feedback-overlay.combo-break::before {
+    background: radial-gradient(circle at center, rgba(255, 70, 110, 0.4), transparent 78%);
+    animation: overlayPulse 0.65s ease-out forwards;
+}
+
+.feedback-overlay.momentum-peak::before {
+    background: radial-gradient(circle at center, rgba(64, 220, 255, 0.35), transparent 70%);
+    animation: overlayGlide 0.6s ease-in-out forwards;
+}
+
+.feedback-overlay.momentum-dip::before {
+    background: radial-gradient(circle at center, rgba(255, 90, 120, 0.32), transparent 82%);
+    animation: overlayPulse 0.7s ease-out forwards;
+}
+
+.feedback-overlay.health-boost::before {
+    background: radial-gradient(circle at center, rgba(140, 255, 200, 0.38), transparent 72%);
+    animation: overlayGlide 0.75s ease-out forwards;
+}
+
+.feedback-overlay.health-loss::before {
+    background: radial-gradient(circle at center, rgba(255, 100, 120, 0.36), transparent 80%);
+    animation: overlayPulse 0.8s ease-out forwards;
+}
+
+.feedback-overlay.score-burst::before {
+    background: radial-gradient(circle at center, rgba(255, 200, 120, 0.36), transparent 76%);
+    animation: overlaySweep 0.7s ease-out forwards;
+}
+
+@keyframes overlayPulse {
+    0% { opacity: 0.7; transform: scale(1); }
+    100% { opacity: 0; transform: scale(1.2); }
+}
+
+@keyframes overlaySweep {
+    0% { opacity: 0.65; transform: scale(0.9); }
+    100% { opacity: 0; transform: scale(1.25); }
+}
+
+@keyframes overlayGlide {
+    0% { opacity: 0.55; filter: blur(0px); }
+    100% { opacity: 0; filter: blur(12px); }
+}
+
+@keyframes burstTrail {
+    0% { opacity: 0; filter: blur(18px); }
+    15% { opacity: 0.85; filter: blur(2px); }
+    60% { opacity: 0.35; filter: blur(10px); }
+    100% { opacity: 0; filter: blur(16px); }
+}
+
+@keyframes momentumPulse {
+    0% { box-shadow: 0 0 0 0 var(--momentum-pulse-color, rgba(0, 255, 255, 0.4)); }
+    50% { box-shadow: 0 0 22px 8px var(--momentum-pulse-color, rgba(0, 255, 255, 0.2)); }
+    100% { box-shadow: 0 0 0 0 rgba(0, 0, 0, 0); }
+}
+
+@keyframes momentumGlow {
+    0% { opacity: 0.35; }
+    60% { opacity: 0.7; }
+    100% { opacity: 0.2; }
+}
+
+.resonance-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 9;
+}
+
+.beat-rings-layer {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 0;
+    height: 0;
+}
+
+.beat-ring {
+    position: absolute;
+    width: 180px;
+    height: 180px;
+    border: 2px solid rgba(255, 255, 255, 0.35);
+    border-radius: 50%;
+    transform: translate(-50%, -50%) scale(var(--ring-scale, 0.8));
+    opacity: 0;
+    mix-blend-mode: screen;
+    transition: opacity 0.15s ease, transform 0.6s ease;
+}
+
+.beat-ring.active {
+    opacity: var(--ring-intensity, 0.6);
+    transform: translate(-50%, -50%) scale(calc(var(--ring-scale, 0.8) * 1.6));
+}
+
+.beat-ring.tone-bass {
+    border-color: rgba(255, 64, 160, 0.6);
+}
+
+.beat-ring.tone-mid {
+    border-color: rgba(64, 180, 255, 0.6);
+}
+
+.beat-ring.tone-high {
+    border-color: rgba(180, 128, 255, 0.6);
+}
+
+.beat-ring.tone-challenge {
+    border-color: rgba(255, 0, 128, 0.6);
+}
+
+.beat-ring.tone-geometry {
+    border-color: rgba(128, 255, 255, 0.6);
+}
+
+.beat-ring.tone-danger {
+    border-color: rgba(255, 64, 64, 0.6);
+}
+
+.beat-ring.tone-combo {
+    border-color: rgba(255, 120, 255, 0.65);
+}
+
+.beat-ring.tone-level {
+    border-color: rgba(120, 255, 180, 0.65);
+}
+
+.beat-ring.tone-system {
+    border-color: rgba(128, 255, 255, 0.55);
+}
+
+.beat-ring.tone-vital {
+    border-color: rgba(140, 255, 200, 0.6);
+}
+
+.beat-ring.tone-momentum {
+    border-color: rgba(64, 220, 255, 0.6);
+}
+
+.beat-ring.tone-score {
+    border-color: rgba(255, 210, 140, 0.65);
+}
+
+.telegraph-grid {
+    position: absolute;
+    inset: 0;
+    background-size: 60px 60px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.telegraph-grid.active {
+    opacity: 0.55;
+}
+
+.telegraph-grid.pattern-challenge {
+    background-image: linear-gradient(0deg, rgba(255, 0, 128, 0.25) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 0, 128, 0.25) 1px, transparent 1px);
+}
+
+.telegraph-grid.pattern-challenge-bass {
+    background-image: linear-gradient(0deg, rgba(255, 64, 160, 0.28) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 64, 160, 0.28) 1px, transparent 1px);
+}
+
+.telegraph-grid.pattern-challenge-mid {
+    background-image: linear-gradient(0deg, rgba(64, 200, 255, 0.28) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(64, 200, 255, 0.28) 1px, transparent 1px);
+}
+
+.telegraph-grid.pattern-challenge-high {
+    background-image: linear-gradient(0deg, rgba(180, 128, 255, 0.28) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(180, 128, 255, 0.28) 1px, transparent 1px);
+}
+
+.telegraph-grid.pattern-surge-bass {
+    background-image: repeating-linear-gradient(45deg, rgba(255, 128, 80, 0.28) 0, rgba(255, 128, 80, 0.28) 6px, transparent 6px, transparent 12px);
+}
+
+.telegraph-grid.pattern-surge-mid {
+    background-image: repeating-linear-gradient(45deg, rgba(80, 180, 255, 0.28) 0, rgba(80, 180, 255, 0.28) 6px, transparent 6px, transparent 12px);
+}
+
+.telegraph-grid.pattern-surge-high {
+    background-image: repeating-linear-gradient(45deg, rgba(180, 120, 255, 0.28) 0, rgba(180, 120, 255, 0.28) 6px, transparent 6px, transparent 12px);
+}
+
+.telegraph-grid.pattern-geometry {
+    background-image: repeating-linear-gradient(135deg, rgba(128, 255, 255, 0.25) 0, rgba(128, 255, 255, 0.25) 8px, transparent 8px, transparent 16px);
+}
+
+.telegraph-grid.pattern-danger {
+    background-image: repeating-linear-gradient(90deg, rgba(255, 0, 0, 0.25) 0, rgba(255, 0, 0, 0.25) 4px, transparent 4px, transparent 12px);
+}
+
+.telegraph-grid.pattern-pause {
+    background: rgba(12, 16, 32, 0.45);
+    backdrop-filter: blur(8px);
+}
+
+.telegraph-grid.pattern-system {
+    background-image: repeating-linear-gradient(0deg, rgba(128, 255, 255, 0.15) 0, rgba(128, 255, 255, 0.15) 2px, transparent 2px, transparent 12px);
+}
+
+.telegraph-grid.pattern-flow {
+    background-image: repeating-linear-gradient(120deg, rgba(64, 180, 255, 0.2) 0, rgba(64, 180, 255, 0.2) 5px, transparent 5px, transparent 14px);
+}
+
+.telegraph-grid.pattern-health-plus {
+    background-image: linear-gradient(0deg, rgba(140, 255, 200, 0.25) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(140, 255, 200, 0.25) 1px, transparent 1px);
+}
+
+.telegraph-grid.pattern-health-minus {
+    background-image: linear-gradient(0deg, rgba(255, 110, 120, 0.28) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 110, 120, 0.28) 1px, transparent 1px);
+}
+
+.telegraph-grid.pattern-combo-break {
+    background-image: repeating-linear-gradient(45deg, rgba(255, 80, 120, 0.3) 0, rgba(255, 80, 120, 0.3) 8px, transparent 8px, transparent 16px);
+}
+
+.telegraph-grid.pattern-momentum {
+    background-image: repeating-linear-gradient(0deg, rgba(64, 220, 255, 0.25) 0, rgba(64, 220, 255, 0.25) 3px, transparent 3px, transparent 12px);
+}
+
+.telegraph-grid.pattern-momentum-low {
+    background-image: repeating-linear-gradient(180deg, rgba(255, 100, 140, 0.28) 0, rgba(255, 100, 140, 0.28) 3px, transparent 3px, transparent 12px);
+}
+
+.telegraph-grid.pattern-score {
+    background-image: repeating-linear-gradient(60deg, rgba(255, 200, 120, 0.28) 0, rgba(255, 200, 120, 0.28) 7px, transparent 7px, transparent 16px);
+}
+
+.cadence-orbit {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 220px;
+    height: 220px;
+    transform: translate(-50%, -50%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.cadence-orbit .orbit-track {
+    position: absolute;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 50%;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.cadence-orbit .track-bass {
+    width: 220px;
+    height: 220px;
+}
+
+.cadence-orbit .track-mid {
+    width: 180px;
+    height: 180px;
+}
+
+.cadence-orbit .track-high {
+    width: 140px;
+    height: 140px;
+}
+
+.cadence-orbit .orbit-dot {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    top: 50%;
+    left: 50%;
+    transform-origin: -90px center;
+    animation: orbitSpin 4s linear infinite;
+    filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.6));
+}
+
+.cadence-orbit .dot-bass {
+    background: rgba(255, 64, 160, 0.9);
+    transform-origin: -110px center;
+    animation-duration: var(--bass-duration, 4s);
+}
+
+.cadence-orbit .dot-mid {
+    background: rgba(64, 200, 255, 0.9);
+    transform-origin: -90px center;
+    animation-duration: var(--mid-duration, 3.6s);
+}
+
+.cadence-orbit .dot-high {
+    background: rgba(180, 128, 255, 0.9);
+    transform-origin: -70px center;
+    animation-duration: var(--high-duration, 3.2s);
+}
+
+@keyframes orbitSpin {
+    0% { transform: rotate(0deg) translateX(0) scale(1); }
+    100% { transform: rotate(360deg) translateX(0) scale(1); }
+}
+
+.burst-trails,
+.status-flare-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    overflow: visible;
+}
+
+.burst-trail {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 140px;
+    height: 140px;
+    border-radius: 50%;
+    transform: translate(calc(-50% + var(--burst-offset-x, 0)), calc(-50% + var(--burst-offset-y, 0))) scale(var(--burst-scale, 1));
+    opacity: 0;
+    mix-blend-mode: screen;
+}
+
+.burst-trail.active {
+    animation: burstTrail var(--burst-duration, 700ms) ease-out forwards;
+}
+
+.burst-trail::after {
+    content: '';
+    position: absolute;
+    inset: -12px;
+    border-radius: 50%;
+    border: 1px solid currentColor;
+    opacity: 0.8;
+}
+
+.status-flare {
+    position: absolute;
+    top: 55%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(0.6);
+    padding: 10px 18px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: rgba(8, 12, 32, 0.75);
+    --flare-color: rgba(128, 255, 255, 0.55);
+    color: rgba(255, 255, 255, 0.85);
+    letter-spacing: 3px;
+    font-size: 10px;
+    text-transform: uppercase;
+    opacity: 0;
+    filter: blur(8px);
+    transition: transform 0.35s ease, opacity 0.35s ease, filter 0.35s ease;
+}
+
+.status-flare.active {
+    transform: translate(-50%, -50%) scale(var(--flare-scale, 1));
+    opacity: 1;
+    filter: blur(0px);
+}
+
+.status-flare::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    box-shadow: 0 0 30px var(--flare-color, rgba(255, 255, 255, 0.2));
+    opacity: 0.6;
+}
+
+.status-flare-label {
+    position: relative;
+    z-index: 1;
+}
+
+.burst-trail.tone-beat { color: rgba(0, 255, 255, 0.7); }
+.burst-trail.tone-challenge { color: rgba(255, 0, 170, 0.7); }
+.burst-trail.tone-surge { color: rgba(255, 196, 0, 0.7); }
+.burst-trail.tone-geometry { color: rgba(128, 255, 255, 0.7); }
+.burst-trail.tone-danger { color: rgba(255, 80, 110, 0.75); }
+.burst-trail.tone-combo { color: rgba(255, 128, 255, 0.75); }
+.burst-trail.tone-level { color: rgba(120, 255, 180, 0.75); }
+.burst-trail.tone-system { color: rgba(128, 255, 255, 0.7); }
+.burst-trail.tone-flow { color: rgba(120, 180, 255, 0.75); }
+.burst-trail.tone-vital { color: rgba(140, 255, 200, 0.78); }
+.burst-trail.tone-momentum { color: rgba(64, 220, 255, 0.78); }
+.burst-trail.tone-score { color: rgba(255, 210, 140, 0.78); }
+
+.status-flare.tone-beat { --flare-color: rgba(0, 255, 255, 0.5); border-color: rgba(0, 255, 255, 0.35); background: rgba(4, 30, 40, 0.8); }
+.status-flare.tone-challenge { --flare-color: rgba(255, 80, 180, 0.5); border-color: rgba(255, 80, 180, 0.4); background: rgba(40, 4, 40, 0.8); }
+.status-flare.tone-surge { --flare-color: rgba(255, 200, 110, 0.5); border-color: rgba(255, 200, 110, 0.35); background: rgba(42, 28, 8, 0.82); }
+.status-flare.tone-geometry { --flare-color: rgba(128, 255, 255, 0.5); border-color: rgba(128, 255, 255, 0.35); background: rgba(8, 26, 38, 0.82); }
+.status-flare.tone-danger { --flare-color: rgba(255, 80, 120, 0.55); border-color: rgba(255, 80, 120, 0.4); background: rgba(38, 10, 18, 0.82); }
+.status-flare.tone-combo { --flare-color: rgba(255, 160, 255, 0.55); border-color: rgba(255, 160, 255, 0.4); background: rgba(36, 6, 36, 0.82); }
+.status-flare.tone-level { --flare-color: rgba(140, 255, 200, 0.55); border-color: rgba(140, 255, 200, 0.4); background: rgba(8, 32, 22, 0.82); }
+.status-flare.tone-system { --flare-color: rgba(128, 255, 255, 0.5); border-color: rgba(128, 255, 255, 0.35); background: rgba(8, 18, 32, 0.82); }
+.status-flare.tone-flow { --flare-color: rgba(120, 180, 255, 0.52); border-color: rgba(120, 180, 255, 0.36); background: rgba(10, 22, 42, 0.82); }
+.status-flare.tone-vital { --flare-color: rgba(140, 255, 200, 0.55); border-color: rgba(140, 255, 200, 0.4); background: rgba(6, 32, 26, 0.82); }
+.status-flare.tone-momentum { --flare-color: rgba(64, 220, 255, 0.55); border-color: rgba(64, 220, 255, 0.4); background: rgba(6, 26, 38, 0.82); }
+.status-flare.tone-score { --flare-color: rgba(255, 210, 140, 0.5); border-color: rgba(255, 210, 140, 0.36); background: rgba(36, 24, 6, 0.82); }
+
+.momentum-meter {
+    position: absolute;
+    bottom: 140px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(320px, 70vw);
+    padding: 14px 18px;
+    border-radius: 16px;
+    background: rgba(8, 12, 40, 0.65);
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    --momentum-pulse-duration: 600ms;
+    --momentum-pulse-color: rgba(0, 255, 255, 0.45);
+}
+
+.momentum-meter .label {
+    font-size: 10px;
+    letter-spacing: 4px;
+    text-align: center;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.momentum-meter .meter-track {
+    position: relative;
+    width: 100%;
+    height: 8px;
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+.momentum-meter .meter-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(90deg, rgba(0, 255, 255, 0.8), rgba(128, 255, 180, 0.8));
+    transition: width 0.3s ease;
+    box-shadow: none;
+}
+
+.momentum-meter .meter-glow {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle, rgba(0, 255, 255, 0.25), transparent 70%);
+    opacity: 0.2;
+    pointer-events: none;
+}
+
+.momentum-meter .meter-value {
+    font-size: 12px;
+    text-align: center;
+    color: rgba(255, 255, 255, 0.7);
+    letter-spacing: 2px;
+}
+
+.momentum-meter[class*='momentum-pulse-'] .meter-fill {
+    animation: momentumPulse var(--momentum-pulse-duration, 600ms) ease-out forwards;
+}
+
+.momentum-meter[class*='momentum-pulse-'] .meter-glow {
+    opacity: 0.35;
+    animation: momentumGlow var(--momentum-pulse-duration, 600ms) ease-out forwards;
+}
+
+.momentum-meter.momentum-pulse-beat { --momentum-pulse-color: rgba(0, 255, 255, 0.5); }
+.momentum-meter.momentum-pulse-beat .meter-fill {
+    background: linear-gradient(90deg, rgba(0, 255, 255, 0.85), rgba(0, 180, 255, 0.8));
+}
+
+.momentum-meter.momentum-pulse-challenge { --momentum-pulse-color: rgba(255, 80, 180, 0.5); }
+.momentum-meter.momentum-pulse-challenge .meter-fill {
+    background: linear-gradient(90deg, rgba(255, 0, 170, 0.85), rgba(255, 140, 220, 0.8));
+}
+
+.momentum-meter.momentum-pulse-surge { --momentum-pulse-color: rgba(255, 200, 110, 0.5); }
+.momentum-meter.momentum-pulse-surge .meter-fill {
+    background: linear-gradient(90deg, rgba(255, 180, 80, 0.85), rgba(255, 220, 120, 0.8));
+}
+
+.momentum-meter.momentum-pulse-geometry { --momentum-pulse-color: rgba(128, 255, 255, 0.5); }
+.momentum-meter.momentum-pulse-geometry .meter-fill {
+    background: linear-gradient(90deg, rgba(128, 255, 255, 0.85), rgba(120, 220, 255, 0.8));
+}
+
+.momentum-meter.momentum-pulse-danger { --momentum-pulse-color: rgba(255, 90, 120, 0.55); }
+.momentum-meter.momentum-pulse-danger .meter-fill {
+    background: linear-gradient(90deg, rgba(255, 90, 120, 0.85), rgba(255, 150, 150, 0.78));
+}
+
+.momentum-meter.momentum-pulse-combo { --momentum-pulse-color: rgba(255, 150, 255, 0.55); }
+.momentum-meter.momentum-pulse-combo .meter-fill {
+    background: linear-gradient(90deg, rgba(255, 140, 255, 0.85), rgba(210, 140, 255, 0.8));
+}
+
+.momentum-meter.momentum-pulse-level { --momentum-pulse-color: rgba(140, 255, 200, 0.55); }
+.momentum-meter.momentum-pulse-level .meter-fill {
+    background: linear-gradient(90deg, rgba(120, 255, 180, 0.85), rgba(160, 255, 200, 0.8));
+}
+
+.momentum-meter.momentum-pulse-system { --momentum-pulse-color: rgba(128, 255, 255, 0.5); }
+.momentum-meter.momentum-pulse-system .meter-fill {
+    background: linear-gradient(90deg, rgba(120, 240, 255, 0.85), rgba(180, 255, 255, 0.8));
+}
+
+.momentum-meter.momentum-pulse-flow { --momentum-pulse-color: rgba(120, 200, 255, 0.5); }
+.momentum-meter.momentum-pulse-flow .meter-fill {
+    background: linear-gradient(90deg, rgba(120, 180, 255, 0.85), rgba(120, 220, 255, 0.8));
+}
+
+.momentum-meter.momentum-pulse-vital { --momentum-pulse-color: rgba(140, 255, 200, 0.55); }
+.momentum-meter.momentum-pulse-vital .meter-fill {
+    background: linear-gradient(90deg, rgba(140, 255, 200, 0.85), rgba(110, 220, 190, 0.8));
+}
+
+.momentum-meter.momentum-pulse-momentum { --momentum-pulse-color: rgba(64, 220, 255, 0.55); }
+.momentum-meter.momentum-pulse-momentum .meter-fill {
+    background: linear-gradient(90deg, rgba(64, 220, 255, 0.85), rgba(120, 220, 255, 0.8));
+}
+
+.momentum-meter.momentum-pulse-score { --momentum-pulse-color: rgba(255, 210, 140, 0.5); }
+.momentum-meter.momentum-pulse-score .meter-fill {
+    background: linear-gradient(90deg, rgba(255, 210, 140, 0.85), rgba(255, 230, 180, 0.8));
+}
+
+.event-feed {
+    position: absolute;
+    top: 18vh;
+    right: min(30px, 4vw);
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+    pointer-events: none;
+    max-width: 240px;
+}
+
+.event-tag {
+    padding: 6px 12px;
+    border-radius: 12px;
+    background: rgba(8, 12, 32, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    font-size: 11px;
+    line-height: 1.4;
+    transform: translateY(10px);
+    opacity: 0;
+    transition: all 0.25s ease;
+}
+
+.event-tag.active {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.event-tag-title {
+    display: block;
+    letter-spacing: 3px;
+    font-size: 10px;
+}
+
+.event-tag-detail {
+    display: block;
+    font-size: 11px;
+    margin-top: 2px;
+}
+
+.event-tag.tone-beat {
+    border-color: rgba(0, 255, 255, 0.4);
+    color: rgba(160, 255, 255, 0.9);
+}
+
+.event-tag.tone-info {
+    border-color: rgba(255, 255, 255, 0.3);
+    color: rgba(240, 240, 255, 0.85);
+}
+
+.event-tag.tone-challenge {
+    border-color: rgba(255, 0, 128, 0.4);
+    color: rgba(255, 160, 220, 0.9);
+}
+
+.event-tag.tone-surge {
+    border-color: rgba(255, 196, 0, 0.4);
+    color: rgba(255, 220, 120, 0.9);
+}
+
+.event-tag.tone-geometry {
+    border-color: rgba(128, 255, 255, 0.4);
+    color: rgba(180, 255, 255, 0.9);
+}
+
+.event-tag.tone-danger {
+    border-color: rgba(255, 64, 64, 0.45);
+    color: rgba(255, 180, 180, 0.9);
+}
+
+.event-tag.tone-combo {
+    border-color: rgba(255, 128, 255, 0.45);
+    color: rgba(255, 190, 255, 0.9);
+}
+
+.event-tag.tone-level {
+    border-color: rgba(128, 255, 180, 0.45);
+    color: rgba(200, 255, 220, 0.9);
+}
+
+.event-tag.tone-system {
+    border-color: rgba(128, 255, 255, 0.35);
+    color: rgba(180, 255, 255, 0.85);
+}
+
+.event-tag.tone-flow {
+    border-color: rgba(80, 180, 255, 0.35);
+    color: rgba(180, 220, 255, 0.85);
+}
+
+.event-tag.tone-vital {
+    border-color: rgba(140, 255, 200, 0.4);
+    color: rgba(200, 255, 220, 0.9);
+}
+
+.event-tag.tone-momentum {
+    border-color: rgba(64, 220, 255, 0.4);
+    color: rgba(180, 245, 255, 0.9);
+}
+
+.event-tag.tone-score {
+    border-color: rgba(255, 210, 140, 0.4);
+    color: rgba(255, 230, 180, 0.9);
+}
+
 /* Overlay Screens */
 .overlay {
     position: absolute;
@@ -446,11 +1170,6 @@ body {
     transform: translate(-50%, -50%) scale(1.2);
 }
 
-/* Beat Flash Effect */
-body.beat-flash {
-    box-shadow: inset 0 0 50px rgba(0, 255, 255, 0.3);
-}
-
 /* Combo Flash Animation */
 .combo-flash {
     animation: comboFlash 0.6s ease;
@@ -460,6 +1179,100 @@ body.beat-flash {
     0% { transform: scale(1); color: #00ffff; }
     50% { transform: scale(1.3); color: #ffff00; text-shadow: 0 0 20px #ffff00; }
     100% { transform: scale(1); color: #00ffff; }
+}
+
+.hud-flash-tick {
+    animation: hudPulse 0.28s ease;
+    --hud-flash-color: rgba(255, 255, 255, 0.35);
+}
+
+.hud-flash-beat {
+    animation: hudPulse 0.32s ease;
+    --hud-flash-color: rgba(0, 255, 255, 0.6);
+}
+
+.hud-flash-challenge {
+    animation: hudPulse 0.35s ease;
+    --hud-flash-color: rgba(255, 0, 128, 0.6);
+}
+
+.hud-flash-surge {
+    animation: hudPulse 0.35s ease;
+    --hud-flash-color: rgba(255, 196, 0, 0.6);
+}
+
+.hud-flash-geometry {
+    animation: hudPulse 0.38s ease;
+    --hud-flash-color: rgba(128, 255, 255, 0.6);
+}
+
+.hud-flash-milestone {
+    animation: hudPulse 0.42s ease;
+    --hud-flash-color: rgba(255, 128, 255, 0.65);
+}
+
+.hud-flash-danger {
+    animation: hudPulse 0.48s ease;
+    --hud-flash-color: rgba(255, 64, 64, 0.65);
+}
+
+.hud-flash-levelup {
+    animation: hudPulse 0.45s ease;
+    --hud-flash-color: rgba(120, 255, 180, 0.65);
+}
+
+.hud-flash-system {
+    animation: hudPulse 0.32s ease;
+    --hud-flash-color: rgba(128, 255, 255, 0.55);
+}
+
+.hud-flash-sublevel {
+    animation: hudPulse 0.36s ease;
+    --hud-flash-color: rgba(64, 180, 255, 0.55);
+}
+
+.hud-flash-vital {
+    animation: hudPulse 0.4s ease;
+    --hud-flash-color: rgba(140, 255, 200, 0.65);
+}
+
+@keyframes hudPulse {
+    0% {
+        box-shadow: 0 0 0 0 var(--hud-flash-color, rgba(255, 255, 255, 0.4));
+        transform: scale(1);
+    }
+    45% {
+        box-shadow: 0 0 18px 0 var(--hud-flash-color, rgba(255, 255, 255, 0.4));
+        transform: scale(1.05);
+    }
+    100% {
+        box-shadow: 0 0 0 0 transparent;
+        transform: scale(1);
+    }
+}
+
+.hud-shake {
+    animation: hudShake 0.36s ease;
+}
+
+.hud-shake-strong {
+    animation: hudShakeStrong 0.52s ease;
+}
+
+@keyframes hudShake {
+    0% { transform: translateX(0); }
+    25% { transform: translateX(-4px); }
+    50% { transform: translateX(3px); }
+    75% { transform: translateX(-2px); }
+    100% { transform: translateX(0); }
+}
+
+@keyframes hudShakeStrong {
+    0% { transform: translateX(0) scale(1); }
+    20% { transform: translateX(-6px) scale(1.04); }
+    45% { transform: translateX(5px) scale(1); }
+    70% { transform: translateX(-4px) scale(1.02); }
+    100% { transform: translateX(0) scale(1); }
 }
 
 /* Responsive Design */
@@ -510,6 +1323,22 @@ body.beat-flash {
 
     .band {
         width: 6px;
+    }
+
+    .momentum-meter {
+        width: min(280px, 88vw);
+        bottom: 120px;
+        padding: 12px 14px;
+    }
+
+    .event-feed {
+        right: min(15px, 3vw);
+        top: 16vh;
+    }
+
+    .cadence-orbit {
+        width: 180px;
+        height: 180px;
     }
 
     #start-screen h1 {
@@ -569,4 +1398,142 @@ input[type="text"]:focus {
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
+}
+
+/* Mobile Optimization Layer */
+.mobile-ux {
+    position: absolute;
+    bottom: 120px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(420px, 90vw);
+    padding: 16px;
+    border-radius: 16px;
+    background: rgba(8, 12, 32, 0.65);
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(12px);
+    display: none;
+    flex-direction: column;
+    gap: 12px;
+    z-index: 50;
+    pointer-events: auto;
+}
+
+body.mobile-experience .mobile-ux {
+    display: flex;
+}
+
+.mobile-ux .status-row,
+.mobile-ux .control-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.mobile-ux .status-chip {
+    flex: 1 1 auto;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(0, 255, 255, 0.12);
+    color: #c8f5ff;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-align: center;
+    text-transform: uppercase;
+}
+
+.mobile-ux .row-label {
+    font-size: 11px;
+    letter-spacing: 0.16em;
+    color: rgba(255, 255, 255, 0.65);
+    text-transform: uppercase;
+    min-width: 100px;
+}
+
+.mobile-ux .chip-group {
+    display: flex;
+    gap: 10px;
+    flex: 1 1 auto;
+}
+
+.mobile-ux .chip {
+    padding: 8px 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.08);
+    color: #fff;
+    font-size: 12px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    cursor: pointer;
+    pointer-events: auto;
+    transition: all 0.2s ease;
+}
+
+.mobile-ux .chip:hover {
+    border-color: rgba(0, 255, 255, 0.45);
+    box-shadow: 0 0 20px rgba(0, 255, 255, 0.25);
+}
+
+.mobile-ux .chip.active {
+    background: linear-gradient(120deg, #00ffff, #ff00ff);
+    color: #050016;
+    box-shadow: 0 0 30px rgba(0, 255, 255, 0.4);
+}
+
+.orientation-warning {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 10px 24px;
+    border-radius: 999px;
+    background: rgba(255, 196, 0, 0.9);
+    color: #120600;
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 60;
+    transition: opacity 0.3s ease;
+}
+
+body.mobile-experience .orientation-warning {
+    display: flex;
+}
+
+.orientation-warning.hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
+body.mobile-experience .orientation-warning:not(.hidden) {
+    opacity: 1;
+}
+
+.hidden {
+    display: none !important;
+}
+
+@media (max-width: 600px) {
+    .mobile-ux {
+        bottom: 96px;
+        padding: 12px;
+        gap: 10px;
+    }
+
+    .mobile-ux .row-label {
+        min-width: unset;
+        flex: 1 1 100%;
+    }
+
+    .mobile-ux .chip-group {
+        justify-content: space-between;
+    }
 }


### PR DESCRIPTION
## Summary
- expand the feedback orchestrator with shared burst/flare/shake helpers and new event coverage for health swings, combo breaks, momentum peaks/dips, and score bursts
- extend the UI, DOM overlays, and styling with burst trails, status flares, momentum pulses, and HUD shakes to reuse micro-interactions everywhere
- detect state swings in the main loop and wire matching haptic patterns for the new event tags

## Testing
- not run (project has no automated test suite)

------
https://chatgpt.com/codex/tasks/task_e_68d39b2e866083299ec644458d3c6456