### PR TITLE
feat: orchestrate shared feedback layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,20 @@ Energy → visual feedback → Timing windows
 - Safari 12+
 - Mobile browsers with WebGL support
 
+## 📱 Mobile Experience
+
+- **Adaptive Profiles**: Auto-detects device tiers (flagship, performance, battery) and tunes render scale, shader density, and audio analysis fidelity accordingly.
+- **Touch Enhancements**: On-screen control center for graphics quality, haptics, and tilt steering toggles built for thumb-friendly access.
+- **Performance Telemetry**: Live FPS and audio latency readouts help players monitor headroom while the engine auto-balances detail.
+- **Orientation Awareness**: Smart overlay guides players to rotate into hyperwide landscape when needed.
+- **Session Persistence**: Remembers last audio source, stream URL, and preferred mobile settings across launches.
+
+## 🎆 Sensory Feedback Layer
+
+- **Beat Ripples & Pulse Rings**: Every beat spawns layered ripples, glowing pulse rings, and floating sync markers that reuse shared shaders for consistent motion language.
+- **HUD Micro-Animations**: Score bursts, combo surges, geometry sigils, and health shocks all draw from the same feedback director so every event gets 5–10 coordinated reactions without bespoke code per element.
+- **Ambient Telemetry**: Background gradients, combo trails, audio bars, and mobile callouts reference unified audio energy metrics—giving music, UI, and touch toggles a single vocabulary of color, motion, and sound cues.
+
 ## 🎵 Audio Support
 
 ### **Input Sources**

--- a/index.html
+++ b/index.html
@@ -57,6 +57,33 @@
             </div>
         </div>
 
+        <!-- Mobile Experience Layer -->
+        <div id="mobile-ux" class="mobile-ux">
+            <div class="status-row">
+                <div class="status-chip" id="mobile-performance-status">-- FPS</div>
+                <div class="status-chip">Latency: <span id="latency-value">interactive</span></div>
+            </div>
+            <div class="control-row">
+                <span class="row-label">Graphics</span>
+                <div class="chip-group">
+                    <button class="chip active" data-graphics-profile="auto">AUTO</button>
+                    <button class="chip" data-graphics-profile="battery">BATTERY</button>
+                    <button class="chip" data-graphics-profile="ultra">ULTRA</button>
+                </div>
+            </div>
+            <div class="control-row">
+                <span class="row-label">Touch Enhancements</span>
+                <div class="chip-group">
+                    <button class="chip" id="toggle-haptics">HAPTICS</button>
+                    <button class="chip active" id="toggle-tilt">TILT ✓</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="orientation-warning" class="orientation-warning hidden">
+            <span>Rotate for Hyperwide Mode</span>
+        </div>
+
         <!-- Start Screen -->
         <div id="start-screen" class="overlay active">
             <h1>VIB34D RHYTHM ROGUELIKE</h1>

--- a/src/core/Parameters.js
+++ b/src/core/Parameters.js
@@ -88,6 +88,51 @@ export class ParameterManager {
             this.setParameter(name, value);
         }
     }
+
+    /**
+     * Apply a named or inline profile to the current parameter set.
+     * Accepts either an object with parameter overrides or a profile name.
+     */
+    applyProfile(profile) {
+        const profiles = {
+            battery: {
+                gridDensity: 12,
+                chaos: 0.15,
+                intensity: 0.5,
+                speed: 0.85
+            },
+            mobile: {
+                gridDensity: 18,
+                chaos: 0.22,
+                intensity: 0.65,
+                speed: 1.0
+            },
+            ultra: {
+                gridDensity: 26,
+                chaos: 0.3,
+                intensity: 0.85,
+                saturation: 0.95
+            }
+        };
+
+        let overrides = {};
+
+        if (typeof profile === 'string') {
+            overrides = profiles[profile] || {};
+        } else if (profile && typeof profile === 'object') {
+            overrides = profile;
+        }
+
+        if (!overrides || !Object.keys(overrides).length) {
+            return;
+        }
+
+        Object.entries(overrides).forEach(([key, value]) => {
+            if (this.parameterDefs[key]) {
+                this.setParameter(key, value);
+            }
+        });
+    }
     
     /**
      * Get a specific parameter value

--- a/src/game/audio/AudioService.js
+++ b/src/game/audio/AudioService.js
@@ -20,18 +20,33 @@ export class AudioService {
         this.energyHistory = [];
         this.historySize = 43; // ~0.7 seconds at 60fps
         this.metronomeEnabled = true;
+        this.latencyHint = 'interactive';
+        this.targetSampleRate = null;
+        this.qualityPreset = 'standard';
+        this.analysisSmoothing = 0.8;
+        this.volumeCeiling = 0.85;
     }
 
     async init() {
         if (this.context) return;
-        this.context = new (window.AudioContext || window.webkitAudioContext)();
+        const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+        const options = {};
+        if (this.latencyHint) options.latencyHint = this.latencyHint;
+        if (this.targetSampleRate) options.sampleRate = this.targetSampleRate;
+
+        try {
+            this.context = new AudioContextClass(options);
+        } catch (error) {
+            console.warn('Falling back to default AudioContext', error);
+            this.context = new AudioContextClass();
+        }
         this.analyser = this.context.createAnalyser();
         this.analyser.fftSize = this.fftSize;
-        this.analyser.smoothingTimeConstant = 0.8;
+        this.analyser.smoothingTimeConstant = this.analysisSmoothing;
         this.frequencyData = new Float32Array(this.analyser.frequencyBinCount);
         this.timeDomainData = new Float32Array(this.analyser.fftSize);
         this.gainNode = this.context.createGain();
-        this.gainNode.gain.value = 0.8;
+        this.gainNode.gain.value = this.volumeCeiling;
         this.analyser.connect(this.gainNode);
         this.gainNode.connect(this.context.destination);
     }
@@ -144,7 +159,8 @@ export class AudioService {
 
     setVolume(value) {
         if (this.gainNode) {
-            this.gainNode.gain.value = value;
+            const clamped = Math.max(0, Math.min(this.volumeCeiling, value));
+            this.gainNode.gain.value = clamped;
         }
     }
 
@@ -154,6 +170,67 @@ export class AudioService {
 
     enableMetronome(enabled) {
         this.metronomeEnabled = enabled;
+    }
+
+    setLatencyHint(latencyHint, sampleRate) {
+        this.latencyHint = latencyHint || this.latencyHint;
+        this.targetSampleRate = sampleRate ?? this.targetSampleRate;
+        if (this.context) {
+            this.rebuildAudioGraph();
+        }
+    }
+
+    async rebuildAudioGraph() {
+        if (!this.context) return this.init();
+
+        const wasPlaying = this.isPlaying;
+        const resumeOffset = this.isPlaying
+            ? this.context.currentTime - this.startTime
+            : this.pauseTime;
+
+        this.stop();
+
+        try {
+            await this.context.close();
+        } catch (error) {
+            console.warn('Failed to close AudioContext cleanly', error);
+        }
+
+        this.context = null;
+        await this.init();
+
+        if (this.trackBuffer) {
+            this.pauseTime = resumeOffset;
+            if (wasPlaying) {
+                this.play();
+            }
+        }
+    }
+
+    setQualityPreset(preset) {
+        const presets = {
+            ultra: { fftSize: 4096, smoothing: 0.7, gain: 0.95 },
+            mobile: { fftSize: 2048, smoothing: 0.8, gain: 0.85 },
+            battery: { fftSize: 1024, smoothing: 0.9, gain: 0.75 },
+            standard: { fftSize: 2048, smoothing: 0.8, gain: 0.85 }
+        };
+
+        const config = presets[preset] || presets.standard;
+        this.qualityPreset = preset || 'standard';
+        this.fftSize = config.fftSize;
+        this.analysisSmoothing = config.smoothing;
+        this.volumeCeiling = config.gain;
+
+        if (this.analyser) {
+            this.analyser.fftSize = this.fftSize;
+            this.analyser.smoothingTimeConstant = this.analysisSmoothing;
+            this.frequencyData = new Float32Array(this.analyser.frequencyBinCount);
+            this.timeDomainData = new Float32Array(this.analyser.fftSize);
+        }
+
+        if (this.gainNode) {
+            this.setVolume(this.gainNode.gain.value);
+        }
     }
 
     onBeat(callback) {

--- a/src/game/feedback/FeedbackDirector.js
+++ b/src/game/feedback/FeedbackDirector.js
@@ -1,0 +1,385 @@
+/**
+ * FeedbackDirector
+ * -----------------------------------------------------------------------------
+ * Centralized orchestration of micro-interactions, visual telegraphy, and
+ * lightweight audio cues that respond to every major player-facing event.
+ *
+ * Each trigger reuses a shared catalogue of overlays, class pulses, and audio
+ * blips so that new events inherit a consistent feedback language instead of
+ * bespoke one-off effects.
+ */
+
+const geometryPalette = ['TETRAHEDRON', 'HYPERCUBE', 'SPHERE', 'TORUS', 'KLEIN BOTTLE', 'FRACTAL', 'WAVE', 'CRYSTAL'];
+
+export class FeedbackDirector {
+    constructor({ container, hudElement, audioService }) {
+        this.container = container;
+        this.hudElement = hudElement;
+        this.audioService = audioService;
+        this.effectLayer = null;
+        this.calloutStack = null;
+        this.comboTrail = null;
+        this.pulseRing = null;
+        this.gridOverlay = null;
+        this.energySmoothing = 0.2;
+        this.comboIntensity = 0;
+        this.lastCombo = 0;
+        this.lastScore = 0;
+        this.lastGeometry = null;
+        this.beatCount = 0;
+        this.pulseTimeout = null;
+        this.activeCallouts = new Set();
+        this.toneContext = null;
+        this.toneGain = null;
+        this.initialized = false;
+    }
+
+    async initialize() {
+        if (this.initialized || !this.container) return;
+
+        this.effectLayer = document.createElement('div');
+        this.effectLayer.className = 'feedback-layer';
+        this.container.appendChild(this.effectLayer);
+
+        this.gridOverlay = document.createElement('div');
+        this.gridOverlay.className = 'feedback-grid-overlay';
+        this.effectLayer.appendChild(this.gridOverlay);
+
+        this.pulseRing = document.createElement('div');
+        this.pulseRing.className = 'feedback-pulse-ring hidden';
+        this.effectLayer.appendChild(this.pulseRing);
+
+        this.comboTrail = document.createElement('div');
+        this.comboTrail.className = 'combo-trail hidden';
+        this.effectLayer.appendChild(this.comboTrail);
+
+        this.calloutStack = document.createElement('div');
+        this.calloutStack.className = 'callout-stack';
+        this.container.appendChild(this.calloutStack);
+
+        this.container.style.setProperty('--energy-glow', '0.2');
+        this.container.style.setProperty('--bass-tilt', '0.5');
+        this.container.style.setProperty('--mid-tilt', '0.5');
+        this.container.style.setProperty('--high-tilt', '0.5');
+        this.container.style.setProperty('--beat-intensity', '0');
+
+        this.toneContext = this.audioService?.context;
+        if (!this.toneContext && typeof window !== 'undefined') {
+            const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+            if (AudioContextClass) {
+                try {
+                    this.toneContext = new AudioContextClass({ latencyHint: 'interactive' });
+                } catch (error) {
+                    console.warn('FeedbackDirector audio context failed to initialize', error);
+                }
+            }
+        }
+
+        if (this.toneContext) {
+            this.toneGain = this.toneContext.createGain();
+            this.toneGain.gain.value = 0.12;
+            this.toneGain.connect(this.toneContext.destination);
+        }
+
+        this.initialized = true;
+    }
+
+    update(deltaTime = 0.016) {
+        if (!this.initialized) return;
+
+        this.comboIntensity = Math.max(0, this.comboIntensity - deltaTime * 0.75);
+        if (this.comboTrail) {
+            if (this.comboIntensity > 0.01) {
+                this.comboTrail.classList.remove('hidden');
+                this.comboTrail.style.opacity = (0.2 + this.comboIntensity * 0.65).toFixed(3);
+                this.comboTrail.style.setProperty('--combo-strength', this.comboIntensity.toFixed(3));
+            } else {
+                this.comboTrail.classList.add('hidden');
+            }
+        }
+    }
+
+    handleBeat(beatData, bands = {}) {
+        if (!this.initialized) return;
+
+        this.beatCount += 1;
+        const energy = this.normalizeIntensity(beatData?.energy ?? bands.energy ?? 0);
+
+        this.container.style.setProperty('--beat-intensity', energy.toFixed(3));
+        this.spawnRipple(energy);
+        this.flashElement(document.body, 'beat-flash', 220);
+        this.flashElement(document.getElementById('score'), 'score-flash', 380);
+        this.flashElement(document.getElementById('combo'), 'combo-surge', 500);
+        this.revealPulseRing(energy, bands);
+
+        if (energy > 0.55 && this.beatCount % 2 === 0) {
+            this.spawnFloatingText('SYNC', 'beat', { decay: 900 });
+        }
+
+        if (this.beatCount % 4 === 0) {
+            this.spawnFloatingText(`x${this.lastCombo}`, 'combo', { decay: 1200 });
+        }
+
+        if (energy > 0.2) {
+            this.playMicroTone(220 + energy * 480, 0.09, 0.18 + energy * 0.24);
+        }
+    }
+
+    updateAmbient(audioData = {}, bands = {}) {
+        if (!this.initialized) return;
+
+        const energy = this.normalizeIntensity(audioData.energy ?? bands.energy ?? 0);
+        this.energySmoothing = this.lerp(this.energySmoothing, energy, 0.12);
+
+        this.container.style.setProperty('--energy-glow', this.energySmoothing.toFixed(3));
+        this.container.style.setProperty('--bass-tilt', this.clamp01(bands.bass || 0.5).toFixed(3));
+        this.container.style.setProperty('--mid-tilt', this.clamp01(bands.mid || 0.5).toFixed(3));
+        this.container.style.setProperty('--high-tilt', this.clamp01(bands.high || 0.5).toFixed(3));
+
+        if (this.gridOverlay) {
+            const hue = ((audioData?.hue ?? 0) + energy * 120) % 360;
+            this.gridOverlay.style.setProperty('--grid-hue', hue.toFixed(1));
+            this.gridOverlay.style.setProperty('--grid-alpha', (0.18 + energy * 0.25).toFixed(3));
+        }
+    }
+
+    handleScoreChange(score, delta = 0, options = {}) {
+        if (!this.initialized) return;
+
+        this.lastScore = score;
+        if (options.immediate || delta === 0) return;
+
+        this.spawnFloatingText(`+${delta}`, 'score', { decay: 1000 });
+        this.flashElement(document.querySelector('.hud-score'), 'score-flash', 420);
+    }
+
+    handleComboChange(combo, source = 'audio') {
+        if (!this.initialized) return;
+
+        if (combo <= 0) {
+            this.comboIntensity = 0;
+            this.lastCombo = 0;
+            if (source !== 'reset') {
+                this.spawnFloatingText('DROP', 'damage', { decay: 900 });
+            }
+            return;
+        }
+
+        if (combo > this.lastCombo) {
+            this.comboIntensity = Math.min(1, this.comboIntensity + 0.25);
+            if (combo === 5 || combo === 10 || combo % 15 === 0) {
+                this.spawnFloatingText(`CHAIN ${combo}`, 'combo', { decay: 1400 });
+            }
+        }
+
+        this.lastCombo = combo;
+
+        if (source !== 'damage' && combo > 1) {
+            this.playMicroTone(420 + combo * 8, 0.06, Math.min(0.45, 0.12 + combo * 0.02));
+        }
+    }
+
+    handleHealthChange(health, context = {}) {
+        if (!this.initialized) return;
+
+        if (health <= 0.35) {
+            this.container.classList.add('low-health');
+        } else {
+            this.container.classList.remove('low-health');
+        }
+
+        if (context.delta !== undefined && context.delta < 0) {
+            this.spawnFloatingText(context.reason === 'drift' ? 'DRIFT' : 'MISS', 'damage', { decay: 1100 });
+            this.flashElement(this.hudElement, 'damage-flash', 260);
+            this.playMicroTone(140, 0.14, 0.22);
+        } else if (context.delta !== undefined && context.delta > 0) {
+            this.spawnFloatingText('+SHIELD', 'heal', { decay: 900 });
+        }
+    }
+
+    handleGeometryChange(geometryName) {
+        if (!this.initialized) return;
+        if (!geometryName) return;
+
+        if (geometryName === this.lastGeometry) return;
+        this.lastGeometry = geometryName;
+
+        const displayName = geometryPalette.includes(geometryName) ? geometryName : geometryName.toString();
+        this.spawnSigil(displayName);
+        this.spawnFloatingText(displayName, 'geometry', { decay: 1600 });
+        this.flashElement(document.getElementById('geometry-display'), 'geometry-flash', 520);
+    }
+
+    handleChallengeCallout(label) {
+        if (!this.initialized || !label) return;
+        this.spawnCallout(label, 'challenge');
+    }
+
+    triggerStartSequence() {
+        if (!this.initialized) return;
+        this.spawnCallout('SYNCHRONIZE', 'system');
+        setTimeout(() => this.spawnCallout('DROP IN', 'success'), 220);
+        setTimeout(() => this.spawnCallout('FLOW STATE', 'info'), 760);
+        this.playMicroTone(320, 0.12, 0.24);
+        this.playMicroTone(520, 0.18, 0.18);
+    }
+
+    triggerPause() {
+        if (!this.initialized) return;
+        this.spawnCallout('PAUSE FIELD', 'info');
+    }
+
+    triggerResume() {
+        if (!this.initialized) return;
+        this.spawnCallout('RESUME VECTOR', 'success');
+        this.playMicroTone(480, 0.12, 0.2);
+    }
+
+    handleReturnToMenu() {
+        if (!this.initialized) return;
+        this.spawnCallout('SESSION STORED', 'info');
+    }
+
+    handleSourceSelection(type, ready) {
+        if (!this.initialized) return;
+        const label = type === 'mic' ? 'MIC LIVE' : type === 'file' ? 'FILE READY' : type === 'stream' ? 'STREAM LINK' : 'SOURCE';
+        this.spawnCallout(`${label}${ready ? ' ✓' : ''}`, ready ? 'success' : 'info');
+    }
+
+    handleMobileProfileChange(profile) {
+        if (!this.initialized) return;
+        this.spawnCallout(`GRAPHICS: ${profile.toUpperCase()}`, 'info');
+    }
+
+    handleMobileToggle(label, enabled) {
+        if (!this.initialized) return;
+        this.spawnCallout(`${label} ${enabled ? 'ENABLED' : 'DISABLED'}`, enabled ? 'success' : 'warning');
+    }
+
+    handleError(message) {
+        if (!this.initialized) return;
+        this.spawnCallout(message, 'error');
+    }
+
+    revealPulseRing(intensity, bands = {}) {
+        if (!this.pulseRing) return;
+
+        this.pulseRing.classList.remove('hidden');
+        this.pulseRing.style.setProperty('--pulse-scale', (0.7 + intensity * 0.9).toFixed(3));
+        this.pulseRing.style.setProperty('--pulse-opacity', (0.25 + intensity * 0.55).toFixed(3));
+        this.pulseRing.style.setProperty('--pulse-rotation', `${Math.round((bands.mid || 0.3) * 180)}deg`);
+
+        if (this.pulseTimeout) {
+            clearTimeout(this.pulseTimeout);
+        }
+        this.pulseTimeout = setTimeout(() => {
+            if (this.pulseRing) {
+                this.pulseRing.classList.add('hidden');
+            }
+        }, 360);
+    }
+
+    spawnRipple(intensity = 0.5) {
+        if (!this.effectLayer) return;
+        const ripple = document.createElement('div');
+        ripple.className = 'beat-ripple';
+        const size = 16 + intensity * 40;
+        ripple.style.setProperty('--ripple-size', `${size}vmin`);
+        ripple.style.setProperty('--ripple-opacity', (0.35 + intensity * 0.45).toFixed(3));
+        ripple.style.left = `${20 + Math.random() * 60}%`;
+        ripple.style.top = `${20 + Math.random() * 60}%`;
+        ripple.style.animationDuration = `${0.6 + intensity * 0.4}s`;
+        this.effectLayer.appendChild(ripple);
+        ripple.addEventListener('animationend', () => ripple.remove());
+    }
+
+    spawnFloatingText(text, type = 'info', options = {}) {
+        if (!this.effectLayer || !text) return;
+
+        const element = document.createElement('div');
+        element.className = `floating-text floating-${type}`;
+        element.textContent = text;
+        element.style.left = `${30 + Math.random() * 40}%`;
+        element.style.top = `${30 + Math.random() * 40}%`;
+        element.style.animationDuration = `${(options.decay || 1000) / 1000}s`;
+        this.effectLayer.appendChild(element);
+        element.addEventListener('animationend', () => element.remove());
+    }
+
+    spawnSigil(label) {
+        if (!this.effectLayer) return;
+        const sigil = document.createElement('div');
+        sigil.className = 'geometry-sigil';
+        sigil.textContent = label;
+        this.effectLayer.appendChild(sigil);
+        sigil.addEventListener('animationend', () => sigil.remove());
+    }
+
+    spawnCallout(message, type = 'info') {
+        if (!this.calloutStack || !message) return;
+
+        const callout = document.createElement('div');
+        callout.className = `callout callout-${type}`;
+        callout.textContent = message;
+        this.calloutStack.appendChild(callout);
+        this.activeCallouts.add(callout);
+
+        requestAnimationFrame(() => callout.classList.add('active'));
+
+        setTimeout(() => {
+            callout.classList.remove('active');
+            setTimeout(() => {
+                if (callout.parentNode) {
+                    callout.parentNode.removeChild(callout);
+                }
+                this.activeCallouts.delete(callout);
+            }, 320);
+        }, 1800);
+    }
+
+    flashElement(element, className, duration = 300) {
+        if (!element) return;
+        element.classList.add(className);
+        setTimeout(() => element.classList.remove(className), duration);
+    }
+
+    playMicroTone(frequency = 320, duration = 0.1, gain = 0.2) {
+        if (!this.toneContext) return;
+        try {
+            if (this.toneContext.state === 'suspended') {
+                this.toneContext.resume();
+            }
+            const oscillator = this.toneContext.createOscillator();
+            oscillator.type = 'sine';
+            oscillator.frequency.value = frequency;
+
+            const gainNode = this.toneContext.createGain();
+            const now = this.toneContext.currentTime;
+            gainNode.gain.setValueAtTime(0, now);
+            gainNode.gain.linearRampToValueAtTime(gain, now + 0.01);
+            gainNode.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+
+            oscillator.connect(gainNode);
+            gainNode.connect(this.toneGain || this.toneContext.destination);
+
+            oscillator.start(now);
+            oscillator.stop(now + duration + 0.05);
+        } catch (error) {
+            console.warn('Micro tone playback failed', error);
+        }
+    }
+
+    normalizeIntensity(value) {
+        const scaled = Math.log10(1 + Math.abs(value) * 12);
+        const normalized = scaled / Math.log10(13);
+        return this.clamp01(normalized);
+    }
+
+    lerp(a, b, t) {
+        return a + (b - a) * t;
+    }
+
+    clamp01(value) {
+        return Math.max(0, Math.min(1, value));
+    }
+}

--- a/src/game/input/InputMapping.js
+++ b/src/game/input/InputMapping.js
@@ -173,13 +173,17 @@ export class InputMapping {
             }
         }
 
-        if (Math.abs(this.tilt.beta) > 1 || Math.abs(this.tilt.gamma) > 1) {
+        const tiltEnabled = typeof window === 'undefined' ? true : window.tiltInputEnabled !== false;
+        if (tiltEnabled && (Math.abs(this.tilt.beta) > 1 || Math.abs(this.tilt.gamma) > 1)) {
             const tiltX = this.tilt.gamma / 90;
             const tiltY = this.tilt.beta / 90;
             this.onParameterDelta?.({
                 rot4dZW: tiltX * 0.3,
                 chaos: Math.abs(tiltY) * 0.05
             });
+        } else if (!tiltEnabled) {
+            this.tilt.beta = 0;
+            this.tilt.gamma = 0;
         }
     }
 

--- a/src/game/mobile/MobileOptimizationManager.js
+++ b/src/game/mobile/MobileOptimizationManager.js
@@ -1,0 +1,316 @@
+/**
+ * MobileOptimizationManager
+ * ---------------------------------------------
+ * Dedicated orchestration layer that adapts the experience to mobile hardware.
+ * It inspects the device profile, configures rendering scale, audio analysis
+ * quality, and exposes UX hooks (graphics presets, haptics, tilt controls).
+ */
+
+export class MobileOptimizationManager {
+    constructor({ canvas, visualizer, parameterManager, audioService, startScreen, feedback, onPreferenceChanged }) {
+        this.canvas = canvas;
+        this.visualizer = visualizer;
+        this.parameterManager = parameterManager;
+        this.audioService = audioService;
+        this.startScreen = startScreen;
+        this.feedback = feedback;
+        this.onPreferenceChanged = onPreferenceChanged;
+
+        this.isMobile = false;
+        this.deviceProfile = 'desktop';
+        this.graphicsProfile = 'auto';
+        this.preferredRenderScale = 1;
+        this.frameSamples = [];
+        this.hapticsEnabled = false;
+        this.tiltEnabled = true;
+        this.motionPermissionRequested = false;
+
+        this.performanceLabel = document.getElementById('mobile-performance-status');
+        this.latencyLabel = document.getElementById('latency-value');
+        this.orientationBanner = document.getElementById('orientation-warning');
+        this.graphicsButtons = Array.from(document.querySelectorAll('[data-graphics-profile]'));
+        this.hapticsButton = document.getElementById('toggle-haptics');
+        this.tiltButton = document.getElementById('toggle-tilt');
+    }
+
+    async initialize() {
+        this.detectDeviceProfile();
+        this.applyDeviceDefaults();
+        this.setupOrientationWatcher();
+        this.bindUiControls();
+    }
+
+    detectDeviceProfile() {
+        if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+            this.isMobile = false;
+            this.deviceProfile = 'desktop';
+            this.preferredRenderScale = 1;
+            return;
+        }
+
+        const ua = navigator.userAgent || '';
+        const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 1;
+        const smallestSide = Math.min(window.innerWidth, window.innerHeight);
+        this.isMobile = /Mobi|Android|iP(ad|hone|od)/i.test(ua) || (isTouch && smallestSide < 1024);
+
+        if (!this.isMobile) {
+            this.deviceProfile = 'desktop';
+            this.preferredRenderScale = 1;
+            return;
+        }
+
+        const deviceMemory = navigator.deviceMemory || 4;
+        const cores = navigator.hardwareConcurrency || 4;
+
+        if (deviceMemory >= 8 && cores >= 8) {
+            this.deviceProfile = 'flagship';
+            this.preferredRenderScale = 1.05;
+        } else if (deviceMemory >= 4 && cores >= 6) {
+            this.deviceProfile = 'performance';
+            this.preferredRenderScale = 0.9;
+        } else {
+            this.deviceProfile = 'battery';
+            this.preferredRenderScale = 0.75;
+        }
+
+        const dpr = window.devicePixelRatio || 1;
+        if (dpr > 1.5) {
+            this.preferredRenderScale /= dpr / 1.5;
+        }
+
+        this.preferredRenderScale = Math.max(0.55, Math.min(1.1, this.preferredRenderScale));
+    }
+
+    applyDeviceDefaults() {
+        if (!this.isMobile || typeof document === 'undefined') return;
+
+        document.body.classList.add('mobile-experience');
+        window.tiltInputEnabled = true;
+
+        if (this.visualizer?.setRenderScale) {
+            this.visualizer.setRenderScale(this.preferredRenderScale);
+        }
+
+        const initialProfile = this.deviceProfile === 'flagship'
+            ? 'ultra'
+            : this.deviceProfile === 'performance'
+                ? 'auto'
+                : 'battery';
+
+        this.setGraphicsProfile(initialProfile, false);
+        this.updateLatencyDisplay(this.audioService?.latencyHint || 'interactive');
+    }
+
+    bindUiControls() {
+        if (!this.isMobile) return;
+
+        this.graphicsButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                const profile = button.dataset.graphicsProfile;
+                this.setGraphicsProfile(profile);
+            });
+        });
+
+        if (this.hapticsButton) {
+            this.hapticsButton.addEventListener('click', () => {
+                this.toggleHaptics();
+            });
+        }
+
+        if (this.tiltButton) {
+            this.tiltButton.addEventListener('click', () => {
+                if (!this.motionPermissionRequested && typeof DeviceOrientationEvent !== 'undefined' &&
+                    typeof DeviceOrientationEvent.requestPermission === 'function') {
+                    DeviceOrientationEvent.requestPermission().finally(() => {
+                        this.motionPermissionRequested = true;
+                        this.toggleTilt(true);
+                    });
+                } else {
+                    this.toggleTilt();
+                }
+            });
+        }
+    }
+
+    setGraphicsProfile(profile, emitPreference = true) {
+        if (!profile) return;
+
+        this.graphicsProfile = profile;
+
+        if (!this.isMobile) {
+            if (emitPreference) {
+                this.onPreferenceChanged?.('graphicsProfile', profile);
+            }
+            return;
+        }
+
+        this.graphicsButtons.forEach(button => {
+            button.classList.toggle('active', button.dataset.graphicsProfile === profile);
+        });
+
+        let renderScale = this.preferredRenderScale;
+        let parameterOverrides = {};
+        let audioPreset = 'standard';
+
+        switch (profile) {
+            case 'ultra':
+                renderScale = Math.min(1.2, this.preferredRenderScale * 1.2);
+                parameterOverrides = {
+                    gridDensity: Math.max(this.parameterManager.getParameter('gridDensity') || 18, 24),
+                    chaos: Math.min(0.35, this.parameterManager.getParameter('chaos') || 0.2),
+                    intensity: 0.85,
+                    saturation: 0.95
+                };
+                audioPreset = 'ultra';
+                break;
+
+            case 'battery':
+                renderScale = Math.max(0.5, this.preferredRenderScale * 0.75);
+                parameterOverrides = {
+                    gridDensity: 12,
+                    chaos: 0.15,
+                    intensity: 0.5,
+                    speed: 0.9
+                };
+                audioPreset = 'battery';
+                break;
+
+            default:
+                renderScale = this.preferredRenderScale;
+                parameterOverrides = {
+                    gridDensity: 18,
+                    chaos: 0.22,
+                    intensity: 0.65,
+                    speed: 1.0
+                };
+                audioPreset = 'mobile';
+                break;
+        }
+
+        if (this.visualizer?.setRenderScale) {
+            this.visualizer.setRenderScale(renderScale);
+        }
+
+        if (this.parameterManager?.applyProfile) {
+            this.parameterManager.applyProfile(parameterOverrides);
+        }
+
+        if (this.audioService?.setQualityPreset) {
+            this.audioService.setQualityPreset(audioPreset);
+        }
+
+        this.updateLatencyDisplay(this.audioService?.latencyHint || 'interactive');
+
+        if (emitPreference) {
+            this.onPreferenceChanged?.('graphicsProfile', profile);
+        }
+
+        if (this.isMobile) {
+            this.feedback?.handleMobileProfileChange(profile);
+        }
+    }
+
+    toggleHaptics(forceValue) {
+        const nextValue = typeof forceValue === 'boolean' ? forceValue : !this.hapticsEnabled;
+        this.hapticsEnabled = nextValue;
+
+        if (this.hapticsButton) {
+            this.hapticsButton.classList.toggle('active', this.hapticsEnabled);
+            this.hapticsButton.textContent = this.hapticsEnabled ? 'HAPTICS ✓' : 'HAPTICS';
+        }
+
+        this.onPreferenceChanged?.('hapticsEnabled', this.hapticsEnabled);
+        if (this.isMobile) {
+            this.feedback?.handleMobileToggle('HAPTICS', this.hapticsEnabled);
+        }
+    }
+
+    toggleTilt(forceValue) {
+        const nextValue = typeof forceValue === 'boolean' ? forceValue : !this.tiltEnabled;
+        this.tiltEnabled = nextValue;
+        window.tiltInputEnabled = this.tiltEnabled;
+
+        if (this.tiltButton) {
+            this.tiltButton.classList.toggle('active', this.tiltEnabled);
+            this.tiltButton.textContent = this.tiltEnabled ? 'TILT ✓' : 'TILT';
+        }
+
+        this.onPreferenceChanged?.('tiltEnabled', this.tiltEnabled);
+        if (this.isMobile) {
+            this.feedback?.handleMobileToggle('TILT', this.tiltEnabled);
+        }
+    }
+
+    recordFrame(deltaTime) {
+        if (!this.isMobile || !this.performanceLabel) return;
+
+        const fps = Math.max(0, Math.min(120, Math.round(1 / Math.max(deltaTime, 0.00001))));
+        this.frameSamples.push(fps);
+
+        if (this.frameSamples.length >= 30) {
+            const average = Math.round(this.frameSamples.reduce((sum, value) => sum + value, 0) / this.frameSamples.length);
+            this.performanceLabel.textContent = `${average} FPS`;
+            this.frameSamples = [];
+        }
+    }
+
+    handleBeat(beatData) {
+        if (!this.hapticsEnabled) return;
+        if (!navigator.vibrate) return;
+
+        const magnitude = Math.min(30, 10 + Math.round((beatData.energy || 0) * 10));
+        const pattern = beatData.source === 'audio' ? [0, magnitude] : [0, 6, 20, 6];
+        try {
+            navigator.vibrate(pattern);
+        } catch (error) {
+            console.warn('Haptic feedback failed:', error);
+        }
+    }
+
+    updateLatencyDisplay(latencyHint) {
+        if (!this.latencyLabel) return;
+        this.latencyLabel.textContent = latencyHint || 'interactive';
+    }
+
+    setupOrientationWatcher() {
+        if (!this.isMobile || !this.orientationBanner) return;
+
+        const evaluateOrientation = () => {
+            const landscape = window.innerWidth >= window.innerHeight;
+            this.orientationBanner.classList.toggle('hidden', landscape);
+        };
+
+        window.addEventListener('resize', evaluateOrientation);
+        window.addEventListener('orientationchange', evaluateOrientation);
+        evaluateOrientation();
+    }
+
+    onGameStart() {
+        if (!this.isMobile) return;
+        this.requestWakeLock();
+    }
+
+    onReturnToMenu() {
+        if (!this.isMobile) return;
+        this.releaseWakeLock();
+    }
+
+    async requestWakeLock() {
+        if (!('wakeLock' in navigator)) return;
+        try {
+            this.wakeLock = await navigator.wakeLock.request('screen');
+        } catch (error) {
+            console.warn('Wake lock unavailable:', error);
+        }
+    }
+
+    async releaseWakeLock() {
+        try {
+            await this.wakeLock?.release?.();
+        } catch (error) {
+            console.warn('Failed to release wake lock:', error);
+        }
+        this.wakeLock = null;
+    }
+}
+

--- a/src/main.js
+++ b/src/main.js
@@ -11,23 +11,41 @@ import { ParameterManager } from './core/Parameters.js';
 import { AudioService } from './game/audio/AudioService.js';
 import { GameUI } from './ui/GameUI.js';
 import { VisualizerEngine } from './core/VisualizerEngine.js';
+import { MobileOptimizationManager } from './game/mobile/MobileOptimizationManager.js';
+import { FeedbackDirector } from './game/feedback/FeedbackDirector.js';
 
 class VIB34DRhythmGame {
     constructor() {
         this.gameCanvas = document.getElementById('game-canvas');
         this.hudElement = document.getElementById('hud');
         this.startScreen = document.getElementById('start-screen');
+        this.gameContainer = document.getElementById('game-container');
 
         // Core systems
         this.parameterManager = new ParameterManager();
         this.audioService = new AudioService();
         this.gameUI = new GameUI();
         this.visualizer = new VisualizerEngine(this.gameCanvas);
+        this.feedback = new FeedbackDirector({
+            container: this.gameContainer,
+            hudElement: this.hudElement,
+            audioService: this.audioService
+        });
 
         // Game state
         this.gameState = 'menu'; // menu, playing, paused, gameOver
         this.currentLevel = 1;
         this.selectedAudioSource = null;
+        this.preferences = this.loadPreferences();
+        this.mobileExperience = null;
+        this.performanceSamples = [];
+        this.score = 0;
+        this.combo = 0;
+        this.health = 1;
+        this.pulseIntensity = 0;
+        this.beatCounter = 0;
+        this.challengeIndex = 0;
+        this.latestAudioBands = { bass: 0, mid: 0, high: 0, energy: 0 };
 
         this.initializeGame();
     }
@@ -40,6 +58,19 @@ class VIB34DRhythmGame {
         // Initialize visualizer with default parameters
         await this.visualizer.initialize();
         this.visualizer.setParameters(this.parameterManager.getAllParameters());
+        await this.feedback.initialize();
+
+        this.mobileExperience = new MobileOptimizationManager({
+            canvas: this.gameCanvas,
+            visualizer: this.visualizer,
+            parameterManager: this.parameterManager,
+            audioService: this.audioService,
+            startScreen: this.startScreen,
+            feedback: this.feedback,
+            onPreferenceChanged: (key, value) => this.updatePreference(key, value)
+        });
+        await this.mobileExperience.initialize();
+        this.applyMobilePreferences();
 
         console.log('VIB34D Rhythm Roguelike initialized');
     }
@@ -51,11 +82,14 @@ class VIB34DRhythmGame {
         // Set canvas size to match container
         const resizeCanvas = () => {
             const rect = container.getBoundingClientRect();
-            canvas.width = rect.width;
-            canvas.height = rect.height;
+            const width = rect.width;
+            const height = rect.height;
 
             if (this.visualizer) {
-                this.visualizer.handleResize(canvas.width, canvas.height);
+                this.visualizer.handleResize(width, height);
+            } else {
+                canvas.width = width;
+                canvas.height = height;
             }
         };
 
@@ -72,15 +106,9 @@ class VIB34DRhythmGame {
 
         sourceButtons.forEach(btn => {
             btn.addEventListener('click', () => {
-                this.selectAudioSource(btn.dataset.source);
-                sourceButtons.forEach(b => b.classList.remove('active'));
-                btn.classList.add('active');
-
-                // Show/hide additional inputs
-                audioFileInput.style.display = btn.dataset.source === 'file' ? 'block' : 'none';
-                streamUrlInput.style.display = btn.dataset.source === 'stream' ? 'block' : 'none';
-
-                startButton.disabled = false;
+                const sourceType = btn.dataset.source;
+                this.selectAudioSource(sourceType);
+                this.applySourceSelectionUI(sourceType, this.hasSourceData(sourceType));
             });
         });
 
@@ -88,16 +116,27 @@ class VIB34DRhythmGame {
         audioFileInput.addEventListener('change', (e) => {
             const file = e.target.files[0];
             if (file) {
-                this.selectedAudioSource = { type: 'file', data: file };
-                startButton.disabled = false;
+                this.selectAudioSource('file');
+                this.selectedAudioSource.data = file;
+                this.applySourceSelectionUI('file', true);
+            } else {
+                this.applySourceSelectionUI('file', false);
             }
         });
 
         // Stream URL handler
         streamUrlInput.addEventListener('input', (e) => {
             if (e.target.value.trim()) {
-                this.selectedAudioSource = { type: 'stream', data: e.target.value.trim() };
-                startButton.disabled = false;
+                const url = e.target.value.trim();
+                this.selectAudioSource('stream');
+                this.selectedAudioSource.data = url;
+                this.applySourceSelectionUI('stream', true);
+                this.updatePreference('lastStreamUrl', url);
+            } else {
+                this.selectAudioSource('stream');
+                this.selectedAudioSource.data = null;
+                this.applySourceSelectionUI('stream', false);
+                this.updatePreference('lastStreamUrl', '');
             }
         });
 
@@ -118,6 +157,8 @@ class VIB34DRhythmGame {
         document.getElementById('resume').addEventListener('click', () => this.resumeGame());
         document.getElementById('restart').addEventListener('click', () => this.restartLevel());
         document.getElementById('quit').addEventListener('click', () => this.quitToMenu());
+
+        this.restoreAudioPreferences();
     }
 
     setupAudioSources() {
@@ -131,14 +172,119 @@ class VIB34DRhythmGame {
         });
     }
 
-    selectAudioSource(sourceType) {
+    resetRunState() {
+        this.score = 0;
+        this.combo = 0;
+        this.health = 1;
+        this.pulseIntensity = 0;
+        this.beatCounter = 0;
+        this.challengeIndex = 0;
+        this.latestAudioBands = { bass: 0, mid: 0, high: 0, energy: 0 };
+
+        this.gameUI.updateScore(this.score);
+        this.gameUI.updateCombo(this.combo);
+        this.gameUI.updateHealth(this.health * 100);
+        this.gameUI.updatePulse(this.pulseIntensity);
+        const params = this.parameterManager.getAllParameters();
+        this.gameUI.updateGeometry(params.geometry);
+        this.gameUI.updateDimension(params.dimension);
+        this.gameUI.updateChaos(params.chaos);
+        this.gameUI.updateAudioBars(0, 0, 0);
+
+        this.feedback?.handleScoreChange(this.score, 0, { immediate: true });
+        this.feedback?.handleComboChange(this.combo, 'reset');
+        this.feedback?.handleHealthChange(this.health, { delta: 0 });
+        this.feedback?.updateAmbient({}, this.latestAudioBands);
+    }
+
+    normalizeEnergy(value) {
+        const scaled = Math.log10(1 + Math.abs(value || 0) * 12);
+        return Math.max(0, Math.min(1, scaled / Math.log10(13)));
+    }
+
+    calculateScoreDelta(intensity, source) {
+        const base = 35 + Math.round(intensity * 180);
+        const comboMultiplier = 1 + this.combo * 0.12;
+        const sourceMultiplier = source === 'audio' ? 1 : 0.45;
+        return Math.max(12, Math.round(base * comboMultiplier * sourceMultiplier));
+    }
+
+    applyDamage(amount, reason = 'miss', options = {}) {
+        const previousHealth = this.health;
+        this.health = Math.max(0, this.health - amount);
+        const delta = this.health - previousHealth;
+        this.gameUI.updateHealth(this.health * 100);
+        this.feedback?.handleHealthChange(this.health, { delta, reason });
+
+        if (options.reduceCombo !== false) {
+            if (reason === 'drift') {
+                this.combo = Math.max(0, Math.floor(this.combo * 0.5));
+            } else {
+                this.combo = 0;
+            }
+        }
+
+        if (this.health <= 0.01) {
+            this.feedback?.handleChallengeCallout('GRID COLLAPSED');
+            this.resetRunState();
+        }
+    }
+
+    applyHealing(amount) {
+        const previousHealth = this.health;
+        this.health = Math.min(1, this.health + amount);
+        const delta = this.health - previousHealth;
+        if (delta !== 0) {
+            this.gameUI.updateHealth(this.health * 100);
+            this.feedback?.handleHealthChange(this.health, { delta, reason: 'heal' });
+        }
+    }
+
+    rotateGeometry() {
+        const params = this.parameterManager.getAllParameters();
+        const nextGeometry = (params.geometry + 1) % 8;
+        params.geometry = nextGeometry;
+        params.hue = (params.hue + 36) % 360;
+        params.morphFactor = Math.min(2, params.morphFactor + 0.05);
+        this.parameterManager.setParameters(params);
+        this.visualizer.setParameters(params);
+        this.gameUI.updateGeometry(nextGeometry);
+        this.feedback?.handleGeometryChange(['TETRAHEDRON', 'HYPERCUBE', 'SPHERE', 'TORUS', 'KLEIN BOTTLE', 'FRACTAL', 'WAVE', 'CRYSTAL'][nextGeometry]);
+    }
+
+    triggerChallengeMoment() {
+        const challengeTypes = ['vertex_precision', 'edge_traversal', 'face_alignment', 'rotation_sync', 'dimensional_shift', 'morphing_adaptation'];
+        const type = challengeTypes[this.challengeIndex % challengeTypes.length];
+        this.challengeIndex += 1;
+        this.gameUI.showChallengeIndicator(type);
+        const label = this.gameUI.getChallengeDisplayName(type);
+        this.feedback?.handleChallengeCallout(label);
+    }
+
+    selectAudioSource(sourceType, persist = true) {
+        if (!sourceType) return;
         this.selectedAudioSource = { type: sourceType };
+        if (persist) {
+            this.updatePreference('lastSourceType', sourceType);
+        }
     }
 
     async startGame() {
         try {
+            if (!this.selectedAudioSource) {
+                alert('Select an audio source to begin.');
+                return;
+            }
+
+            if ((this.selectedAudioSource.type === 'file' || this.selectedAudioSource.type === 'stream') &&
+                !this.selectedAudioSource.data) {
+                alert('Provide an audio file or stream URL before starting.');
+                return;
+            }
+
             this.startScreen.classList.remove('active');
             this.gameState = 'playing';
+            this.resetRunState();
 
             // Initialize audio based on selected source
             await this.initializeAudio();
@@ -146,11 +292,18 @@ class VIB34DRhythmGame {
             // Start the game loop
             this.startGameLoop();
 
+            this.updatePreference('lastSessionTimestamp', Date.now());
+            const sessionCount = (this.preferences.sessionCount || 0) + 1;
+            this.updatePreference('sessionCount', sessionCount);
+            this.mobileExperience?.onGameStart();
+            this.feedback?.triggerStartSequence();
+
             console.log('Game started with audio source:', this.selectedAudioSource.type);
 
         } catch (error) {
             console.error('Failed to start game:', error);
             alert('Failed to initialize audio. Please check your audio source.');
+            this.feedback?.handleError('AUDIO INIT FAILED');
             this.quitToMenu();
         }
     }
@@ -207,6 +360,14 @@ class VIB34DRhythmGame {
 
         // Update game UI
         this.gameUI.update(deltaTime);
+        this.feedback?.update(deltaTime);
+
+        if (this.pulseIntensity > 0) {
+            this.pulseIntensity = Math.max(0, this.pulseIntensity - deltaTime * 0.6);
+        }
+
+        // Feed performance metrics to the mobile experience layer
+        this.mobileExperience?.recordFrame(deltaTime);
     }
 
     render() {
@@ -218,11 +379,47 @@ class VIB34DRhythmGame {
     }
 
     handleBeat(beatData) {
+        const intensity = this.normalizeEnergy(beatData?.energy ?? this.latestAudioBands.energy ?? 0);
+
+        if (beatData.source === 'audio') {
+            this.combo = Math.min(this.combo + 1, 99);
+        } else {
+            this.combo = Math.max(0, Math.floor(this.combo * 0.5));
+        }
+
+        const scoreDelta = this.calculateScoreDelta(intensity, beatData.source);
+        this.score += scoreDelta;
+
+        if (beatData.source !== 'audio' || intensity < 0.18) {
+            const damage = beatData.source === 'audio' ? 0.05 : 0.08;
+            this.applyDamage(damage, 'drift', { reduceCombo: false });
+            this.combo = Math.max(0, Math.floor(this.combo * 0.6));
+        } else if (intensity > 0.55) {
+            this.applyHealing(0.02 * intensity);
+        }
+
+        this.gameUI.updateScore(this.score);
+        this.gameUI.updateCombo(this.combo);
+
+        this.feedback?.handleBeat(beatData, this.latestAudioBands);
+        this.feedback?.handleScoreChange(this.score, scoreDelta);
+        this.feedback?.handleComboChange(this.combo, beatData.source);
+
         // Generate geometric challenges based on beat
         this.generateBeatChallenge(beatData);
 
         // Update UI beat indicator
         this.gameUI.showBeatIndicator();
+
+        this.beatCounter += 1;
+        if (this.beatCounter % 8 === 0) {
+            this.rotateGeometry();
+        }
+        if (this.beatCounter % 6 === 0) {
+            this.triggerChallengeMoment();
+        }
+
+        this.mobileExperience?.handleBeat(beatData);
 
         console.log('Beat detected:', beatData);
     }
@@ -235,6 +432,7 @@ class VIB34DRhythmGame {
         const bassLevel = audioData.frequencyData ? this.getFrequencyRange(audioData.frequencyData, 0, 0.1) : 0;
         const midLevel = audioData.frequencyData ? this.getFrequencyRange(audioData.frequencyData, 0.1, 0.5) : 0;
         const highLevel = audioData.frequencyData ? this.getFrequencyRange(audioData.frequencyData, 0.5, 1.0) : 0;
+        const energy = audioData.energy ?? (this.normalizeEnergy((bassLevel + midLevel + highLevel) / 3));
 
         // Update parameters based on audio analysis
         params.gridDensity = 15 + (bassLevel * 25); // 15-40 range
@@ -245,8 +443,18 @@ class VIB34DRhythmGame {
         this.parameterManager.setParameters(params);
         this.visualizer.setParameters(params);
 
-        // Update audio visualization bars in HUD
+        this.latestAudioBands = {
+            bass: Math.max(0, Math.min(1, bassLevel)),
+            mid: Math.max(0, Math.min(1, midLevel)),
+            high: Math.max(0, Math.min(1, highLevel)),
+            energy: energy
+        };
+
+        this.pulseIntensity = Math.max(this.pulseIntensity, Math.min(1, (bassLevel + midLevel) / 2));
+
+        // Update audio visualization bars in HUD and feedback ambient state
         this.updateAudioBars(bassLevel, midLevel, highLevel);
+        this.feedback?.updateAmbient({ ...(audioData || {}), energy }, this.latestAudioBands);
     }
 
     getFrequencyRange(frequencyData, startPercent, endPercent) {
@@ -292,26 +500,29 @@ class VIB34DRhythmGame {
     }
 
     updateHUD() {
-        // Update score, combo, level displays
-        // This will be connected to actual game state
-        document.getElementById('score').textContent = '0';
-        document.getElementById('combo').textContent = '0x';
-        document.getElementById('level').textContent = `${this.currentLevel}-1`;
+        this.gameUI.updateScore(this.score);
+        this.gameUI.updateCombo(this.combo);
+        const subLevel = Math.max(1, Math.floor(this.beatCounter / 8) + 1);
+        this.gameUI.updateLevel(this.currentLevel, subLevel);
 
-        // Update geometry display
-        const geometryNames = ['TETRAHEDRON', 'HYPERCUBE', 'SPHERE', 'TORUS', 'KLEIN BOTTLE', 'FRACTAL', 'WAVE', 'CRYSTAL'];
         const params = this.parameterManager.getAllParameters();
-        document.getElementById('geometry-display').textContent = geometryNames[params.geometry] || 'HYPERCUBE';
-
-        // Update dimension meter
-        const dimensionPercent = ((params.dimension - 3.0) / 1.5) * 100;
-        document.querySelector('#dimension-meter .meter-fill').style.width = `${dimensionPercent}%`;
+        this.gameUI.updateGeometry(params.geometry);
+        this.gameUI.updateDimension(params.dimension);
+        this.gameUI.updateChaos(params.chaos);
+        this.gameUI.updatePulse(this.pulseIntensity);
+        this.gameUI.updateHealth(this.health * 100);
+        this.gameUI.updateAudioBars(
+            this.latestAudioBands.bass || 0,
+            this.latestAudioBands.mid || 0,
+            this.latestAudioBands.high || 0
+        );
     }
 
     updateAudioBars(bass, mid, high) {
-        document.getElementById('bass-band').style.height = `${bass * 100}%`;
-        document.getElementById('mid-band').style.height = `${mid * 100}%`;
-        document.getElementById('high-band').style.height = `${high * 100}%`;
+        const clamp = (value) => Math.max(0, Math.min(1, value || 0));
+        document.getElementById('bass-band').style.height = `${clamp(bass) * 100}%`;
+        document.getElementById('mid-band').style.height = `${clamp(mid) * 100}%`;
+        document.getElementById('high-band').style.height = `${clamp(high) * 100}%`;
     }
 
     togglePause() {
@@ -326,6 +537,7 @@ class VIB34DRhythmGame {
         this.gameState = 'paused';
         this.audioService.pause();
         document.getElementById('pause-menu').classList.add('active');
+        this.feedback?.triggerPause();
     }
 
     resumeGame() {
@@ -333,10 +545,12 @@ class VIB34DRhythmGame {
         this.audioService.play();
         document.getElementById('pause-menu').classList.remove('active');
         this.startGameLoop();
+        this.feedback?.triggerResume();
     }
 
     restartLevel() {
         // Restart current level
+        this.resetRunState();
         this.resumeGame();
         // Additional restart logic will be added
     }
@@ -346,10 +560,116 @@ class VIB34DRhythmGame {
         this.audioService.stop();
         document.getElementById('pause-menu').classList.remove('active');
         this.startScreen.classList.add('active');
+        this.resetRunState();
+        this.feedback?.handleReturnToMenu();
 
         // Reset game state
         this.currentLevel = 1;
         this.selectedAudioSource = null;
+        this.mobileExperience?.onReturnToMenu();
+    }
+
+    hasSourceData(sourceType) {
+        if (sourceType === 'mic') return true;
+        if (!this.selectedAudioSource) return false;
+        if (this.selectedAudioSource.type !== sourceType) {
+            return sourceType === 'mic';
+        }
+        return Boolean(this.selectedAudioSource.data);
+    }
+
+    applySourceSelectionUI(sourceType, hasData = false) {
+        const sourceButtons = document.querySelectorAll('.source-btn');
+        const audioFileInput = document.getElementById('audio-file');
+        const streamUrlInput = document.getElementById('stream-url');
+        const startButton = document.getElementById('start-game');
+
+        sourceButtons.forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.source === sourceType);
+        });
+
+        if (audioFileInput) {
+            audioFileInput.style.display = sourceType === 'file' ? 'block' : 'none';
+        }
+
+        if (streamUrlInput) {
+            streamUrlInput.style.display = sourceType === 'stream' ? 'block' : 'none';
+        }
+
+        const canStart = sourceType === 'mic' || hasData;
+        if (startButton) {
+            startButton.disabled = !canStart;
+        }
+
+        this.feedback?.handleSourceSelection(sourceType, canStart);
+    }
+
+    restoreAudioPreferences() {
+        const sourceType = this.preferences?.lastSourceType;
+        if (!sourceType) return;
+
+        if (sourceType === 'stream' && this.preferences.lastStreamUrl) {
+            const streamInput = document.getElementById('stream-url');
+            if (streamInput) {
+                streamInput.value = this.preferences.lastStreamUrl;
+            }
+            this.selectedAudioSource = { type: 'stream', data: this.preferences.lastStreamUrl };
+        }
+
+        this.selectAudioSource(sourceType, false);
+        const hasData = this.hasSourceData(sourceType);
+        this.applySourceSelectionUI(sourceType, hasData);
+    }
+
+    applyMobilePreferences() {
+        if (!this.mobileExperience || !this.preferences) return;
+
+        if (this.preferences.graphicsProfile) {
+            this.mobileExperience.setGraphicsProfile(this.preferences.graphicsProfile, false);
+        }
+
+        if (typeof this.preferences.hapticsEnabled === 'boolean') {
+            this.mobileExperience.toggleHaptics(this.preferences.hapticsEnabled);
+        }
+
+        if (typeof this.preferences.tiltEnabled === 'boolean') {
+            this.mobileExperience.toggleTilt(this.preferences.tiltEnabled);
+        }
+    }
+
+    loadPreferences() {
+        if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
+            return {};
+        }
+
+        try {
+            const stored = localStorage.getItem('vib34d-mobile-prefs');
+            return stored ? JSON.parse(stored) : {};
+        } catch (error) {
+            console.warn('Failed to read stored preferences', error);
+            return {};
+        }
+    }
+
+    savePreferences() {
+        if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
+            return;
+        }
+
+        try {
+            localStorage.setItem('vib34d-mobile-prefs', JSON.stringify(this.preferences));
+        } catch (error) {
+            console.warn('Failed to persist preferences', error);
+        }
+    }
+
+    updatePreference(key, value) {
+        if (!this.preferences) {
+            this.preferences = {};
+        }
+
+        this.preferences[key] = value;
+        this.savePreferences();
     }
 }
 

--- a/styles/game.css
+++ b/styles/game.css
@@ -25,7 +25,13 @@ body {
     left: 0;
     width: 100vw;
     height: 100vh;
-    background: linear-gradient(45deg, #0a0015, #1a001a, #000030);
+    --energy-glow: 0.2;
+    --bass-tilt: 0.5;
+    --mid-tilt: 0.5;
+    --high-tilt: 0.5;
+    --beat-intensity: 0;
+    background: radial-gradient(circle at 50% 50%, rgba(10, 0, 30, 0.9), #000030 60%);
+    overflow: hidden;
 }
 
 /* Main Game Canvas */
@@ -213,8 +219,9 @@ body {
     width: 8px;
     min-height: 2px;
     background: linear-gradient(to top, #ff0000, #ffff00, #00ff00);
-    transition: height 0.1s ease;
+    transition: height 0.1s ease, box-shadow 0.2s ease;
     border-radius: 4px 4px 0 0;
+    box-shadow: 0 0 calc(6px + var(--beat-intensity) * 24px) rgba(0, 255, 255, 0.15);
 }
 
 .band.bass {
@@ -569,4 +576,393 @@ input[type="text"]:focus {
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
+}
+
+/* Mobile Optimization Layer */
+.mobile-ux {
+    position: absolute;
+    bottom: 120px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(420px, 90vw);
+    padding: 16px;
+    border-radius: 16px;
+    background: rgba(8, 12, 32, 0.65);
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(12px);
+    display: none;
+    flex-direction: column;
+    gap: 12px;
+    z-index: 50;
+    pointer-events: auto;
+}
+
+body.mobile-experience .mobile-ux {
+    display: flex;
+}
+
+.mobile-ux .status-row,
+.mobile-ux .control-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.mobile-ux .status-chip {
+    flex: 1 1 auto;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(0, 255, 255, 0.12);
+    color: #c8f5ff;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-align: center;
+    text-transform: uppercase;
+}
+
+.mobile-ux .row-label {
+    font-size: 11px;
+    letter-spacing: 0.16em;
+    color: rgba(255, 255, 255, 0.65);
+    text-transform: uppercase;
+    min-width: 100px;
+}
+
+.mobile-ux .chip-group {
+    display: flex;
+    gap: 10px;
+    flex: 1 1 auto;
+}
+
+.mobile-ux .chip {
+    padding: 8px 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.08);
+    color: #fff;
+    font-size: 12px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    cursor: pointer;
+    pointer-events: auto;
+    transition: all 0.2s ease;
+}
+
+.mobile-ux .chip:hover {
+    border-color: rgba(0, 255, 255, 0.45);
+    box-shadow: 0 0 20px rgba(0, 255, 255, 0.25);
+}
+
+.mobile-ux .chip.active {
+    background: linear-gradient(120deg, #00ffff, #ff00ff);
+    color: #050016;
+    box-shadow: 0 0 30px rgba(0, 255, 255, 0.4);
+}
+
+.orientation-warning {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 10px 24px;
+    border-radius: 999px;
+    background: rgba(255, 196, 0, 0.9);
+    color: #120600;
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 60;
+    transition: opacity 0.3s ease;
+}
+
+body.mobile-experience .orientation-warning {
+    display: flex;
+}
+
+.orientation-warning.hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
+body.mobile-experience .orientation-warning:not(.hidden) {
+    opacity: 1;
+}
+
+.hidden {
+    display: none !important;
+}
+
+@media (max-width: 600px) {
+    .mobile-ux {
+        bottom: 96px;
+        padding: 12px;
+        gap: 10px;
+    }
+
+    .mobile-ux .row-label {
+        min-width: unset;
+        flex: 1 1 100%;
+    }
+
+    .mobile-ux .chip-group {
+        justify-content: space-between;
+    }
+}
+
+/* Feedback & Micro Interaction Layer */
+#game-container::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+        radial-gradient(circle at calc(var(--bass-tilt) * 100%) calc(var(--mid-tilt) * 100%), rgba(0, 255, 255, calc(0.08 + var(--energy-glow) * 0.45)), transparent 65%),
+        radial-gradient(circle at calc(var(--mid-tilt) * 100%) calc(var(--high-tilt) * 100%), rgba(255, 0, 255, calc(0.06 + var(--energy-glow) * 0.35)), transparent 70%);
+    mix-blend-mode: screen;
+    opacity: calc(0.2 + var(--energy-glow) * 0.6);
+    transition: opacity 0.3s ease, transform 0.35s ease;
+    transform: rotate(calc((var(--beat-intensity) - 0.5) * 12deg));
+}
+
+#game-container::after {
+    content: '';
+    position: absolute;
+    inset: -25%;
+    pointer-events: none;
+    background: conic-gradient(from 180deg, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0));
+    opacity: calc(0.15 + var(--energy-glow) * 0.4);
+    transition: opacity 0.4s ease;
+}
+
+#game-container.low-health::after {
+    background: radial-gradient(circle at 50% 50%, rgba(255, 64, 64, 0.4), transparent 70%);
+    opacity: 0.65;
+}
+
+#hud.damage-flash {
+    animation: damageFlash 0.28s ease;
+}
+
+@keyframes damageFlash {
+    0% { filter: none; }
+    40% { filter: drop-shadow(0 0 24px rgba(255, 64, 64, 0.55)); }
+    100% { filter: none; }
+}
+
+#score.score-flash {
+    animation: scorePulse 0.4s ease;
+}
+
+.hud-score.score-flash {
+    box-shadow: 0 0 30px rgba(0, 255, 255, 0.35);
+}
+
+@keyframes scorePulse {
+    0% { transform: scale(1); text-shadow: 0 0 6px rgba(0, 255, 255, 0.5); }
+    50% { transform: scale(1.3); text-shadow: 0 0 26px rgba(0, 255, 255, 0.8); }
+    100% { transform: scale(1); text-shadow: 0 0 8px rgba(0, 255, 255, 0.5); }
+}
+
+#combo.combo-surge {
+    animation: comboSurge 0.5s ease-out;
+}
+
+@keyframes comboSurge {
+    0% { transform: scale(1); letter-spacing: 0.1em; }
+    45% { transform: scale(1.3); letter-spacing: 0.25em; text-shadow: 0 0 18px rgba(255, 0, 255, 0.75); }
+    100% { transform: scale(1); letter-spacing: 0.14em; }
+}
+
+#geometry-display.geometry-flash {
+    display: inline-block;
+    animation: geometryPulse 0.6s ease;
+}
+
+@keyframes geometryPulse {
+    0% { transform: scale(1); color: #fff; }
+    40% { transform: scale(1.2); color: #ffff80; text-shadow: 0 0 30px rgba(255, 255, 128, 0.8); }
+    100% { transform: scale(1); color: #fff; }
+}
+
+.feedback-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 5;
+}
+
+.feedback-grid-overlay {
+    position: absolute;
+    inset: -25%;
+    pointer-events: none;
+    background-image:
+        linear-gradient(90deg, rgba(0, 255, 255, 0.06) 1px, transparent 1px),
+        linear-gradient(0deg, rgba(255, 0, 255, 0.06) 1px, transparent 1px);
+    background-size: 40px 40px;
+    opacity: var(--grid-alpha, 0.22);
+    transform: rotate(18deg);
+    transition: opacity 0.3s ease;
+    mix-blend-mode: lighten;
+    filter: hue-rotate(calc(var(--grid-hue, 180) * 1deg));
+}
+
+.feedback-pulse-ring {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 36vmin;
+    height: 36vmin;
+    border-radius: 50%;
+    border: 2px solid rgba(0, 255, 255, 0.35);
+    transform: translate(-50%, -50%) scale(var(--pulse-scale, 0.8)) rotate(var(--pulse-rotation, 0deg));
+    opacity: var(--pulse-opacity, 0.3);
+    transition: transform 0.22s ease, opacity 0.22s ease;
+    box-shadow: 0 0 40px rgba(0, 255, 255, 0.25);
+}
+
+.feedback-pulse-ring.hidden {
+    opacity: 0;
+}
+
+.combo-trail {
+    position: absolute;
+    bottom: 18%;
+    left: 50%;
+    transform: translateX(-50%) scaleX(calc(0.5 + var(--combo-strength, 0.2)));
+    transform-origin: center;
+    width: 60%;
+    height: 4px;
+    background: linear-gradient(90deg, rgba(255, 0, 255, 0), rgba(255, 0, 255, 0.8), rgba(0, 255, 255, 0));
+    filter: blur(0.4px);
+    opacity: 0;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.combo-trail.hidden {
+    opacity: 0;
+}
+
+.beat-ripple {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: var(--ripple-size, 18vmin);
+    height: var(--ripple-size, 18vmin);
+    border-radius: 50%;
+    border: 2px solid rgba(0, 255, 255, var(--ripple-opacity, 0.45));
+    transform: translate(-50%, -50%) scale(0.35);
+    animation: beatRipple 0.8s ease-out forwards;
+    pointer-events: none;
+    mix-blend-mode: screen;
+}
+
+@keyframes beatRipple {
+    0% { transform: translate(-50%, -50%) scale(0.35); opacity: 0.85; }
+    70% { opacity: 0.35; }
+    100% { transform: translate(-50%, -50%) scale(1.7); opacity: 0; }
+}
+
+.floating-text {
+    position: absolute;
+    font-size: 16px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    pointer-events: none;
+    transform: translate(-50%, -50%);
+    animation: floatRise 1.3s ease-out forwards;
+    text-shadow: 0 0 12px rgba(255, 255, 255, 0.4);
+}
+
+.floating-text.floating-score { color: #00ffff; }
+.floating-text.floating-combo { color: #ff80ff; }
+.floating-text.floating-geometry { color: #ffe066; }
+.floating-text.floating-beat { color: #80ffea; }
+.floating-text.floating-damage { color: #ff4f6d; text-shadow: 0 0 16px rgba(255, 64, 100, 0.6); }
+.floating-text.floating-heal { color: #7dff9f; }
+
+@keyframes floatRise {
+    0% { opacity: 0.9; transform: translate(-50%, -40%) scale(0.8); }
+    100% { opacity: 0; transform: translate(-50%, -180%) scale(1.2); }
+}
+
+.geometry-sigil {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 180px;
+    height: 180px;
+    border-radius: 50%;
+    border: 2px solid rgba(0, 255, 255, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform: translate(-50%, -50%);
+    color: #fff;
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    pointer-events: none;
+    mix-blend-mode: screen;
+    backdrop-filter: blur(6px);
+    animation: sigilPulse 1.4s ease-out forwards;
+}
+
+@keyframes sigilPulse {
+    0% { opacity: 0; transform: translate(-50%, -50%) scale(0.6); }
+    40% { opacity: 0.8; }
+    100% { opacity: 0; transform: translate(-50%, -50%) scale(1.6); }
+}
+
+.callout-stack {
+    position: absolute;
+    bottom: 14%;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    pointer-events: none;
+    z-index: 80;
+}
+
+.callout {
+    padding: 10px 22px;
+    border-radius: 999px;
+    font-size: 12px;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    background: rgba(8, 16, 32, 0.8);
+    color: #c8f5ff;
+    border: 1px solid rgba(0, 255, 255, 0.4);
+    opacity: 0;
+    transform: translateY(10px) scale(0.95);
+    transition: transform 0.25s ease, opacity 0.25s ease;
+    box-shadow: 0 0 18px rgba(0, 255, 255, 0.15);
+}
+
+.callout.active {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+}
+
+.callout-system { border-color: rgba(255, 255, 128, 0.5); color: #fff3a0; }
+.callout-success { border-color: rgba(0, 255, 128, 0.5); color: #afffd6; }
+.callout-info { border-color: rgba(0, 255, 255, 0.5); color: #b4ffff; }
+.callout-warning { border-color: rgba(255, 200, 0, 0.6); color: #ffe8a0; }
+.callout-error { border-color: rgba(255, 64, 64, 0.6); color: #ffb4b4; }
+.callout-challenge { border-color: rgba(255, 0, 255, 0.5); color: #ffd4ff; }
+
+body.beat-flash {
+    box-shadow: inset 0 0 120px rgba(0, 255, 255, calc(0.32 + var(--beat-intensity) * 0.5));
+    background-color: rgba(0, 12, 24, calc(0.1 + var(--beat-intensity) * 0.2));
 }


### PR DESCRIPTION
## Summary
- add a reusable FeedbackDirector that spawns beat ripples, floating text, callouts, and micro-tones so every event shares the same feedback catalogue
- drive score/combo/health progression inside the main loop, emit geometry/challenge sweeps, and route mobile toggles through the director for synchronized cues
- style the ambient gradients, combo trails, callouts, and pulse overlays plus document the new sensory feedback layer in the README

## Testing
- not run (project has no automated test suite)

------
https://chatgpt.com/codex/tasks/task_e_68d39b2e866083299ec644458d3c6456