### PR TITLE
Add regression coverage for context recovery and resource pressure

### DIFF
--- a/ARCHITECTURE_PROGRESS.md
+++ b/ARCHITECTURE_PROGRESS.md
@@ -1,0 +1,22 @@
+# Architecture Refactor Progress
+
+## Completed Work
+- **Canvas lifecycle stabilisation** – Implemented `CanvasResourcePool` to preallocate per-system layer stacks, register pooled contexts with the resource manager, and coordinate resize handling so visualization swaps no longer churn the DOM or drop WebGL state.【F:src/core/CanvasManager.js†L1-L195】【F:src/core/CanvasManager.js†L197-L334】
+- **Engine orchestration foundation** – Added an `EngineCoordinator` that initialises engines in order, provisions shared buffers/textures/shaders once, enforces lifecycle contracts, and relays parameter updates and broadcasts across the active system set.【F:src/core/EngineCoordinator.js†L1-L204】【F:src/core/EngineCoordinator.js†L219-L357】
+- **GPU resource management** – Established a `ResourceManager` that registers contexts, tracks buffers/textures/programs, monitors memory pressure, and exposes helpers for common assets like gradients and noise fields.【F:src/core/ResourceManager.js†L1-L160】【F:src/core/ResourceManager.js†L222-L420】
+- **Predictable state container** – Delivered a Redux-style `StateManager` with domain reducers, validation/persistence middleware, bounded history, and localStorage restore hooks to centralise gameplay, audio, UI, and system state.【F:src/core/StateManager.js†L1-L120】【F:src/core/StateManager.js†L224-L520】
+- **Visualizer facade integration** – Refactored `VisualizerEngine` to assemble the pool/coordinator/managers, mirror audio analytics into state, route gameplay events through broadcasts, and keep visualization parameters aligned with the store.【F:src/core/VisualizerEngine.js†L1-L252】【F:src/core/VisualizerEngine.js†L264-L512】
+- **Audio & interaction parameter mapping** – Added a `ParameterMappingSystem` that fuses base visualization parameters with audio-reactive bands and live interaction metrics, producing effective uniforms for the coordinator while preserving stateful baselines.【F:src/core/ParameterMappingSystem.js†L1-L237】【F:src/core/VisualizerEngine.js†L233-L365】
+- **Layered shader rebuild** – Replaced bespoke per-system implementations with a shared `BaseLayeredEngine` that clones shared GPU blueprints through the `ResourceManager`, renders pooled canvases with coordinated shader pipelines, and centralises audio/gameplay reactivity across all engines.【F:src/core/BaseLayeredEngine.js†L1-L409】【F:src/core/Engine.js†L1-L69】【F:src/quantum/QuantumEngine.js†L1-L75】【F:src/holograms/RealHolographicSystem.js†L1-L70】【F:src/core/PolychoraSystem.js†L1-L79】
+- **Resource usage tracking** – Captured shared buffer/texture/shader ownership per engine and mapped pooled resource handles to durable IDs so the coordinator can record attachment/detachment against the ResourceManager audit trail.【F:src/core/ResourceManager.js†L220-L360】【F:src/core/EngineCoordinator.js†L1-L192】
+- **Hypercube fallback integration** – Provisioned dedicated pooled canvases and refactored the hypercube visualizer to consume pooled WebGL contexts, enabling seamless mode toggles without recreating contexts.【F:src/core/CanvasManager.js†L10-L86】【F:src/visualizers/HypercubeGameSystem.js†L1-L120】【F:src/core/VisualizerEngine.js†L180-L224】
+- **Orchestration validation harness** – Added a Node-based smoke test runner that exercises state persistence and engine switching/teardown workflows ahead of the testing break.【F:tests/run-tests.js†L1-L214】
+- **Visual baseline capture tooling** – Implemented a `BaselineCaptureManager` that reuses the coordinator, canvas pool, and parameter mapper to snapshot canonical frames and wired it into the visualizer facade with regression coverage.【F:src/core/BaselineCaptureManager.js†L1-L210】【F:src/core/VisualizerEngine.js†L1-L347】【F:tests/run-tests.js†L400-L470】
+- **Context loss & memory pressure regression coverage** – Added smoke tests that drive the `CanvasResourcePool` through WebGL loss/recovery flows and force the `ResourceManager` to shed least-used allocations under constrained budgets.【F:tests/run-tests.js†L1-L244】【F:tests/run-tests.js†L470-L611】
+
+## Remaining Work Before Refactor & Testing Break
+- **Browser baseline validation** – Capture canonical frames from the real renderer to compare against the automated baselines before freezing the refactor.
+
+## Next Steps
+1. Capture visual baselines for the new shader pipelines to confirm parity with the original systems before further optimisation.
+2. Perform manual validation of captured baselines inside the browser renderer and tune thresholds ahead of the testing break.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ npx serve -p 8000
 open http://localhost:8000
 ```
 
+## ✅ Testing & Validation
+
+```bash
+npm test
+```
+
+The test harness runs lightweight Node-based integration checks that validate the architecture refactor:
+
+- **State persistence** – Confirms the Redux-inspired `StateManager` serialises and restores gameplay/system state exactly as documented in the architectural analysis.
+- **Engine orchestration** – Exercises the `EngineCoordinator` lifecycle (initialisation, switching, resizing, teardown) with stub engines to ensure resource sharing and activation flows remain deterministic.
+
 ### **Requirements**
 - Modern browser with WebGL 2.0 support
 - Audio input permission for microphone mode

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "vib34d-rhythm-roguelike",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "node tests/run-tests.js"
+  }
+}

--- a/src/core/BaseLayeredEngine.js
+++ b/src/core/BaseLayeredEngine.js
@@ -1,0 +1,667 @@
+/**
+ * BaseLayeredEngine
+ * ------------------------------------------------------------
+ * Shared implementation for the refactored visualization engines.
+ * Each engine consumes pooled canvases, clones the required shared GPU
+ * assets through the ResourceManager, and renders layered shader-driven
+ * visuals that react to audio and gameplay events. The design follows
+ * the production architecture captured in COMPREHENSIVE_ARCHITECTURE_ANALYSIS.md
+ * and PROPER_ARCHITECTURE_SOLUTIONS.md by centralising lifecycle
+ * management, enforcing deterministic initialisation, and ensuring all
+ * GPU allocations flow through the ResourceManager.
+ */
+
+const DEFAULT_VERTEX_SHADER = `
+  attribute vec2 a_position;
+  attribute vec2 a_uv;
+
+  varying vec2 v_uv;
+
+  void main() {
+    v_uv = a_uv;
+    gl_Position = vec4(a_position, 0.0, 1.0);
+  }
+`;
+
+const DEFAULT_FRAGMENT_SHADER = `
+  precision highp float;
+
+  varying vec2 v_uv;
+
+  uniform sampler2D u_gradient;
+  uniform vec3 u_colorA;
+  uniform vec3 u_colorB;
+  uniform float u_time;
+  uniform float u_intensity;
+  uniform float u_energy;
+  uniform float u_detail;
+  uniform float u_morph;
+  uniform float u_chaos;
+  uniform float u_combo;
+  uniform float u_highlight;
+  uniform float u_mix;
+
+  void main() {
+    vec2 uv = v_uv;
+    float wave = sin(u_time * (0.7 + u_detail * 0.6) + uv.y * (6.28318 + u_chaos * 9.0)) * 0.5 + 0.5;
+    vec3 gradientColour = texture2D(u_gradient, vec2(fract(uv.x + u_combo * 0.1), fract(u_time * 0.08 + u_energy * 0.2))).rgb;
+    vec3 mixed = mix(u_colorA, u_colorB, wave);
+    mixed = mix(mixed, gradientColour, clamp(u_mix, 0.0, 1.0));
+    mixed += u_highlight * 0.25;
+    float alpha = clamp(u_intensity + u_energy * 0.4 + u_highlight * 0.3, 0.0, 1.0);
+    gl_FragColor = vec4(mixed * (0.25 + u_intensity * 0.75), alpha);
+  }
+`;
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function hslToRgb(h, s, l) {
+  const hue = ((h % 360) + 360) % 360;
+  const saturation = clamp(s, 0, 1);
+  const lightness = clamp(l, 0, 1);
+
+  if (saturation === 0) {
+    return [lightness, lightness, lightness];
+  }
+
+  const q = lightness < 0.5
+    ? lightness * (1 + saturation)
+    : lightness + saturation - lightness * saturation;
+  const p = 2 * lightness - q;
+
+  const hueToRgb = (t) => {
+    let tt = t;
+    if (tt < 0) tt += 1;
+    if (tt > 1) tt -= 1;
+    if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+    if (tt < 1 / 2) return q;
+    if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+    return p;
+  };
+
+  const r = hueToRgb((hue / 360) + 1 / 3);
+  const g = hueToRgb(hue / 360);
+  const b = hueToRgb((hue / 360) - 1 / 3);
+  return [r, g, b];
+}
+
+export class BaseLayeredEngine {
+  constructor({
+    canvasResources = {},
+    sharedResources = new Map(),
+    resourceManager = null,
+    systemName = 'engine',
+    config = {},
+    palette = {},
+  } = {}) {
+    this.canvasResources = canvasResources;
+    this.sharedResources = sharedResources || new Map();
+    this.resourceManager = resourceManager;
+    this.systemName = systemName;
+    this.config = config;
+    this.palette = palette;
+
+    this.layerOrder = Array.isArray(config?.requiredLayers)
+      ? [...config.requiredLayers]
+      : Object.keys(canvasResources);
+
+    this.layerPipelines = new Map();
+    this.parameters = { ...this.getDefaultParameters() };
+    this.parameterBounds = this.getParameterBounds();
+
+    this.audioState = {
+      energy: 0,
+      bass: 0,
+      mid: 0,
+      high: 0,
+    };
+
+    this.effectState = {
+      beat: 0,
+      damage: 0,
+      highlight: 0,
+      chaos: 0,
+      combo: 0,
+    };
+
+    this.effectDecay = {
+      beat: 1.8,
+      damage: 1.2,
+      highlight: 1.6,
+      chaos: 0.9,
+      combo: 0.65,
+    };
+
+    this.isActive = false;
+    this.lastTimestamp = 0;
+
+    this.sharedBlueprints = {
+      buffers: new Map(),
+      textures: new Map(),
+      shaders: new Map(),
+    };
+  }
+
+  attachSharedResources(sharedResources, requirements = {}) {
+    this.sharedResources = sharedResources || new Map();
+
+    Object.entries(requirements || {}).forEach(([type, keys]) => {
+      if (!Array.isArray(keys)) {
+        return;
+      }
+
+      keys.forEach((key) => {
+        const store = this.sharedBlueprints[type];
+        const shared = this.sharedResources.get(type)?.get(key);
+        if (!store || !shared) {
+          return;
+        }
+        store.set(key, shared);
+      });
+    });
+  }
+
+  getDefaultParameters() {
+    return {
+      geometry: 0,
+      gridDensity: 15,
+      morphFactor: 1,
+      chaos: 0.2,
+      speed: 1,
+      hue: 200,
+      intensity: 0.5,
+      saturation: 0.8,
+      dimension: 3.5,
+      rot4dXW: 0,
+      rot4dYW: 0,
+      rot4dZW: 0,
+    };
+  }
+
+  getParameterBounds() {
+    return {
+      geometry: { min: 0, max: 7 },
+      gridDensity: { min: 4, max: 100 },
+      morphFactor: { min: 0, max: 2 },
+      chaos: { min: 0, max: 1 },
+      speed: { min: 0.05, max: 3 },
+      hue: { min: 0, max: 360 },
+      intensity: { min: 0, max: 1 },
+      saturation: { min: 0, max: 1 },
+      dimension: { min: 3, max: 4.5 },
+      rot4dXW: { min: -2, max: 2 },
+      rot4dYW: { min: -2, max: 2 },
+      rot4dZW: { min: -2, max: 2 },
+    };
+  }
+
+  async initialize() {
+    this.layerOrder.forEach((layerName) => {
+      const resource = this.canvasResources[layerName];
+      if (!resource) {
+        return;
+      }
+
+      const pipeline = this.createLayerPipeline(layerName, resource);
+      if (pipeline) {
+        this.layerPipelines.set(layerName, pipeline);
+      }
+    });
+
+    this.onParametersUpdated();
+  }
+
+  createLayerPipeline(layerName, resource) {
+    const { canvas, context, contextId } = resource || {};
+    const gl = context
+      || canvas?.getContext?.('webgl2')
+      || canvas?.getContext?.('webgl');
+
+    if (!gl) {
+      console.warn(`${this.systemName}: missing WebGL context for layer ${layerName}`);
+      return null;
+    }
+
+    if (contextId && this.resourceManager) {
+      const contexts = this.resourceManager.contexts;
+      const hasContext = typeof contexts?.has === 'function' ? contexts.has(contextId) : false;
+      if (!hasContext) {
+        try {
+          this.resourceManager.registerWebGLContext?.(contextId, gl, { label: `${this.systemName}:${layerName}` });
+        } catch (error) {
+          console.warn(`${this.systemName}: unable to register context ${contextId}`, error);
+        }
+      }
+    }
+
+    const vertexSource = this.getVertexShaderSource(layerName);
+    const fragmentSource = this.getFragmentShaderSource(layerName);
+
+    const programRecord = this.resourceManager
+      ? this.resourceManager.createProgram(contextId, vertexSource, fragmentSource)
+      : null;
+    const programHandle = programRecord?.program || programRecord?.handle;
+
+    if (!programHandle) {
+      console.warn(`${this.systemName}: failed to create shader program for ${layerName}`);
+      return null;
+    }
+
+    const bufferData = this.resolveBufferData('screen_quad');
+    const bufferRecord = bufferData && this.resourceManager
+      ? this.resourceManager.createBuffer(contextId, bufferData)
+      : null;
+
+    if (!bufferRecord?.buffer) {
+      console.warn(`${this.systemName}: unable to create screen quad buffer for ${layerName}`);
+      return null;
+    }
+
+    const gradientDescriptor = this.resolveGradientDescriptor('gradient_lut');
+    const gradientRecord = gradientDescriptor && this.resourceManager
+      ? this.resourceManager.createTexture(contextId, gradientDescriptor)
+      : null;
+
+    const positionLocation = gl.getAttribLocation(programHandle, 'a_position');
+    const uvLocation = gl.getAttribLocation(programHandle, 'a_uv');
+
+    const uniforms = {
+      gradient: gl.getUniformLocation(programHandle, 'u_gradient'),
+      colorA: gl.getUniformLocation(programHandle, 'u_colorA'),
+      colorB: gl.getUniformLocation(programHandle, 'u_colorB'),
+      time: gl.getUniformLocation(programHandle, 'u_time'),
+      intensity: gl.getUniformLocation(programHandle, 'u_intensity'),
+      energy: gl.getUniformLocation(programHandle, 'u_energy'),
+      detail: gl.getUniformLocation(programHandle, 'u_detail'),
+      morph: gl.getUniformLocation(programHandle, 'u_morph'),
+      chaos: gl.getUniformLocation(programHandle, 'u_chaos'),
+      combo: gl.getUniformLocation(programHandle, 'u_combo'),
+      highlight: gl.getUniformLocation(programHandle, 'u_highlight'),
+      mix: gl.getUniformLocation(programHandle, 'u_mix'),
+    };
+
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+    return {
+      name: layerName,
+      canvas,
+      contextId,
+      gl,
+      program: programHandle,
+      programRecord,
+      buffer: bufferRecord,
+      gradient: gradientRecord,
+      attributes: {
+        position: positionLocation,
+        uv: uvLocation,
+      },
+      uniforms,
+      resources: [programRecord?.id, bufferRecord?.id, gradientRecord?.id].filter(Boolean),
+      palette: this.getLayerPalette(layerName),
+    };
+  }
+
+  resolveBufferData(name) {
+    const shared = this.sharedBlueprints.buffers.get(name);
+    if (shared?.metadata?.data) {
+      return shared.metadata.data.slice();
+    }
+
+    if (name === 'screen_quad') {
+      return new Float32Array([
+        -1, -1, 0, 0,
+        1, -1, 1, 0,
+        -1, 1, 0, 1,
+        1, 1, 1, 1,
+      ]);
+    }
+
+    return null;
+  }
+
+  resolveGradientDescriptor(name) {
+    const shared = this.sharedBlueprints.textures.get(name);
+    const metadata = shared?.metadata;
+
+    if (metadata?.data && metadata?.width && metadata?.height) {
+      return {
+        width: metadata.width,
+        height: metadata.height,
+        data: metadata.data.slice ? metadata.data.slice() : metadata.data,
+      };
+    }
+
+    const stops = 256;
+    const data = new Uint8Array(stops * 4);
+    for (let i = 0; i < stops; i += 1) {
+      const t = i / (stops - 1);
+      const hue = t * 360;
+      const rgb = hslToRgb(hue, 1, 0.5);
+      data[i * 4 + 0] = Math.floor(rgb[0] * 255);
+      data[i * 4 + 1] = Math.floor(rgb[1] * 255);
+      data[i * 4 + 2] = Math.floor(rgb[2] * 255);
+      data[i * 4 + 3] = 255;
+    }
+
+    return { width: stops, height: 1, data };
+  }
+
+  getVertexShaderSource() {
+    return DEFAULT_VERTEX_SHADER;
+  }
+
+  getFragmentShaderSource() {
+    return DEFAULT_FRAGMENT_SHADER;
+  }
+
+  getLayerPalette(layerName) {
+    return this.palette[layerName] || {};
+  }
+
+  setActive(active) {
+    this.isActive = Boolean(active);
+    if (this.isActive) {
+      this.lastTimestamp = 0;
+    }
+  }
+
+  deactivate() {
+    this.setActive(false);
+  }
+
+  render(timestamp = 0) {
+    if (!this.isActive) {
+      return;
+    }
+
+    const deltaSeconds = this.lastTimestamp > 0
+      ? Math.max(0, (timestamp - this.lastTimestamp) / 1000)
+      : 0.016;
+    this.lastTimestamp = timestamp;
+
+    Object.entries(this.effectState).forEach(([key, value]) => {
+      const decay = this.effectDecay[key] ?? 1;
+      this.effectState[key] = Math.max(0, value - deltaSeconds * decay);
+    });
+
+    this.layerPipelines.forEach((pipeline) => {
+      const { gl, canvas, program, buffer, gradient, attributes, uniforms, palette } = pipeline;
+
+      if (!canvas || !program || !buffer?.buffer) {
+        return;
+      }
+
+      const width = canvas.width || canvas.clientWidth || 1;
+      const height = canvas.height || canvas.clientHeight || 1;
+      gl.viewport(0, 0, width, height);
+
+      gl.useProgram(program);
+
+      gl.bindBuffer(gl.ARRAY_BUFFER, buffer.buffer);
+
+      if (attributes.position >= 0) {
+        gl.enableVertexAttribArray(attributes.position);
+        gl.vertexAttribPointer(attributes.position, 2, gl.FLOAT, false, 16, 0);
+      }
+
+      if (attributes.uv >= 0) {
+        gl.enableVertexAttribArray(attributes.uv);
+        gl.vertexAttribPointer(attributes.uv, 2, gl.FLOAT, false, 16, 8);
+      }
+
+      if (gradient?.texture || gradient?.handle) {
+        const textureHandle = gradient.texture || gradient.handle;
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, textureHandle);
+        if (uniforms.gradient) {
+          gl.uniform1i(uniforms.gradient, 0);
+        }
+      }
+
+      const uniformsPayload = this.computeLayerUniforms(pipeline, palette);
+
+      if (uniforms.colorA && uniformsPayload.colorA) {
+        gl.uniform3fv(uniforms.colorA, uniformsPayload.colorA);
+      }
+
+      if (uniforms.colorB && uniformsPayload.colorB) {
+        gl.uniform3fv(uniforms.colorB, uniformsPayload.colorB);
+      }
+
+      if (uniforms.time) {
+        gl.uniform1f(uniforms.time, timestamp / 1000);
+      }
+
+      if (uniforms.intensity) {
+        gl.uniform1f(uniforms.intensity, uniformsPayload.intensity);
+      }
+
+      if (uniforms.energy) {
+        gl.uniform1f(uniforms.energy, this.audioState.energy);
+      }
+
+      if (uniforms.detail) {
+        gl.uniform1f(uniforms.detail, uniformsPayload.detail);
+      }
+
+      if (uniforms.morph) {
+        gl.uniform1f(uniforms.morph, uniformsPayload.morph);
+      }
+
+      if (uniforms.chaos) {
+        gl.uniform1f(uniforms.chaos, uniformsPayload.chaos);
+      }
+
+      if (uniforms.combo) {
+        gl.uniform1f(uniforms.combo, this.effectState.combo);
+      }
+
+      if (uniforms.highlight) {
+        gl.uniform1f(uniforms.highlight, this.effectState.highlight);
+      }
+
+      if (uniforms.mix) {
+        gl.uniform1f(uniforms.mix, uniformsPayload.mix);
+      }
+
+      gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+
+      if (attributes.position >= 0) {
+        gl.disableVertexAttribArray(attributes.position);
+      }
+      if (attributes.uv >= 0) {
+        gl.disableVertexAttribArray(attributes.uv);
+      }
+
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+      gl.useProgram(null);
+    });
+  }
+
+  computeLayerUniforms(pipeline, palette = {}) {
+    const hue = (this.parameters.hue ?? 0) + (palette.hueOffset ?? 0);
+    const hueSpread = palette.hueSpread ?? 30;
+    const saturation = clamp((this.parameters.saturation ?? 0.8) * (palette.saturation ?? 1), 0, 1);
+    const baseLightness = clamp(palette.lightness ?? 0.4, 0, 1);
+    const highlightLightness = clamp(baseLightness + (palette.lightnessShift ?? 0.15), 0, 1);
+
+    const colorA = hslToRgb(hue, saturation, baseLightness);
+    const colorB = hslToRgb(hue + hueSpread, saturation, highlightLightness);
+
+    const intensityBase = clamp((this.parameters.intensity ?? 0.5) * (palette.intensity ?? 1), 0, 1.5);
+    const intensity = clamp(
+      intensityBase
+        + (palette.energyImpact ?? 0.4) * this.audioState.energy
+        + (palette.beatImpact ?? 0.35) * this.effectState.beat
+        + (palette.highlightImpact ?? 0.25) * this.effectState.highlight
+        - (palette.damageImpact ?? 0.2) * this.effectState.damage,
+      0,
+      1.5,
+    );
+
+    const detail = clamp(((this.parameters.gridDensity ?? 15) - 4) / 96, 0, 1);
+    const morph = clamp((this.parameters.morphFactor ?? 1) / 2, 0, 1);
+    const chaosParam = clamp((this.parameters.chaos ?? 0) + this.effectState.chaos * 0.6, 0, 2);
+    const mix = clamp((palette.mix ?? 0.55) + (palette.energyMix ?? 0.25) * this.audioState.mid, 0, 1);
+
+    return {
+      colorA: new Float32Array(colorA),
+      colorB: new Float32Array(colorB),
+      intensity,
+      detail,
+      morph,
+      chaos: chaosParam,
+      mix,
+    };
+  }
+
+  handleResize(width, height) {
+    this.layerPipelines.forEach(({ gl, canvas }) => {
+      if (!gl || !canvas) {
+        return;
+      }
+
+      const w = width || canvas.width || canvas.clientWidth || 1;
+      const h = height || canvas.height || canvas.clientHeight || 1;
+      gl.viewport(0, 0, w, h);
+    });
+  }
+
+  setParameters(parameters = {}) {
+    Object.entries(parameters || {}).forEach(([key, value]) => {
+      this.parameters[key] = this.clampParameter(key, value);
+    });
+    this.onParametersUpdated();
+  }
+
+  updateParameters(parameters = {}) {
+    this.setParameters({ ...this.parameters, ...parameters });
+  }
+
+  clampParameter(key, value) {
+    const bounds = this.parameterBounds[key];
+    if (!bounds) {
+      return value;
+    }
+    const clamped = clamp(value, bounds.min, bounds.max);
+    if (key === 'geometry') {
+      return Math.round(clamped);
+    }
+    return clamped;
+  }
+
+  onParametersUpdated() {
+    // Sub-classes can override to react to parameter changes.
+  }
+
+  onAudioData(audioData = {}) {
+    if (audioData.energy !== undefined) {
+      this.audioState.energy = clamp(audioData.energy, 0, 1);
+    }
+    if (audioData.bass !== undefined) {
+      this.audioState.bass = clamp(audioData.bass, 0, 1);
+    }
+    if (audioData.mid !== undefined) {
+      this.audioState.mid = clamp(audioData.mid, 0, 1);
+    }
+    if (audioData.high !== undefined) {
+      this.audioState.high = clamp(audioData.high, 0, 1);
+    }
+  }
+
+  explodeBeat(intensity = 1) {
+    this.effectState.beat = Math.max(this.effectState.beat, clamp(intensity, 0, 2));
+    return true;
+  }
+
+  triggerComboFireworks(comboCount = 0, normalizedIntensity = 0.5) {
+    const magnitude = Math.max(comboCount / 10, normalizedIntensity);
+    this.effectState.combo = Math.max(this.effectState.combo, clamp(magnitude, 0, 1.5));
+    return true;
+  }
+
+  highlightSystemInteractions(eventType, intensity = 1) {
+    if (eventType === 'damage') {
+      return this.damageShockwave(intensity * 50);
+    }
+
+    this.effectState.highlight = Math.max(this.effectState.highlight, clamp(intensity, 0, 1.5));
+    return true;
+  }
+
+  enemyGlitchStorm(intensity = 1) {
+    this.effectState.chaos = Math.max(this.effectState.chaos, clamp(intensity, 0, 1.5));
+    return true;
+  }
+
+  damageShockwave(amount = 0) {
+    const normalized = clamp(Math.abs(amount) / 100, 0, 2);
+    this.effectState.damage = Math.max(this.effectState.damage, normalized);
+    return true;
+  }
+
+  powerUpNova(powerLevel = 1) {
+    this.effectState.highlight = Math.max(this.effectState.highlight, clamp(powerLevel, 0, 1.5));
+    this.effectState.combo = Math.max(this.effectState.combo, clamp(powerLevel * 0.5, 0, 1.5));
+    return true;
+  }
+
+  levelTranscendence(level = 1) {
+    this.effectState.highlight = Math.max(this.effectState.highlight, clamp(level / 10, 0, 1));
+    return true;
+  }
+
+  enterBossRealityRift() {
+    this.effectState.chaos = Math.max(this.effectState.chaos, 1);
+    this.effectState.highlight = Math.max(this.effectState.highlight, 0.8);
+    return true;
+  }
+
+  setTacticalInfo() {
+    this.effectState.highlight = Math.max(this.effectState.highlight, 0.4);
+    return true;
+  }
+
+  activateHypertetrahedronMode() {
+    this.parameters.geometry = 0;
+    this.parameters.dimension = 4;
+    return true;
+  }
+
+  triggerTacticalGlitchStorm(intensity = 1) {
+    return this.enemyGlitchStorm(intensity);
+  }
+
+  handleResizeForResource(resource) {
+    if (!resource) {
+      return;
+    }
+    const { canvas, gl } = resource;
+    if (canvas && gl) {
+      gl.viewport(0, 0, canvas.width, canvas.height);
+    }
+  }
+
+  destroy() {
+    if (!this.resourceManager) {
+      return;
+    }
+
+    this.layerPipelines.forEach((pipeline) => {
+      pipeline.resources?.forEach((id) => {
+        try {
+          this.resourceManager.releaseResource?.(id);
+        } catch (error) {
+          console.warn(`${this.systemName}: failed to release resource ${id}`, error);
+        }
+      });
+    });
+
+    this.layerPipelines.clear();
+  }
+}
+
+export default BaseLayeredEngine;

--- a/src/core/BaselineCaptureManager.js
+++ b/src/core/BaselineCaptureManager.js
@@ -1,0 +1,238 @@
+/**
+ * BaselineCaptureManager
+ * ------------------------------------------------------------
+ * Utility that captures visual baselines for each engine without
+ * reimplementing orchestration logic. It leverages the existing
+ * EngineCoordinator, CanvasResourcePool and ParameterMappingSystem
+ * so captures honour the refactored architecture.
+ */
+
+const PERF = (typeof performance !== 'undefined' && performance?.now)
+  ? performance
+  : { now: () => Date.now() };
+
+const DEFAULT_LAYER_PREFERENCE = ['content', 'highlight', 'background', 'shadow', 'accent', 0];
+
+function clone(value) {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.slice();
+  }
+  return { ...value };
+}
+
+function normaliseRequests(requests) {
+  if (!Array.isArray(requests)) {
+    return [];
+  }
+  return requests
+    .map((request) => (request && typeof request === 'object' ? request : null))
+    .filter(Boolean);
+}
+
+export class BaselineCaptureManager {
+  constructor({
+    engineCoordinator = null,
+    canvasPool = null,
+    parameterMappingSystem = null,
+    clock = () => PERF.now(),
+  } = {}) {
+    this.engineCoordinator = engineCoordinator;
+    this.canvasPool = canvasPool;
+    this.parameterMappingSystem = parameterMappingSystem;
+    this.clock = typeof clock === 'function' ? clock : () => PERF.now();
+  }
+
+  async captureBaselines(requests = [], options = {}) {
+    const normalised = normaliseRequests(requests);
+    if (normalised.length === 0) {
+      return [];
+    }
+
+    const previousSystem = this.engineCoordinator?.getActiveSystem?.() || null;
+    const originalBase = this.parameterMappingSystem?.getBaseParameters?.();
+    const originalAudio = this.parameterMappingSystem?.getAudioState?.();
+    const originalInteraction = this.parameterMappingSystem?.getInteractionState?.();
+
+    const results = [];
+
+    try {
+      for (const request of normalised) {
+        const result = await this.captureSingleBaseline(request, options);
+        if (result) {
+          results.push(result);
+        }
+      }
+    } finally {
+      if (previousSystem && typeof this.engineCoordinator?.switchEngine === 'function') {
+        try {
+          await this.engineCoordinator.switchEngine(previousSystem);
+        } catch (error) {
+          console.warn('BaselineCaptureManager: failed to restore previous system', error);
+        }
+      }
+
+      if (this.parameterMappingSystem) {
+        try {
+          if (originalBase) {
+            this.parameterMappingSystem.setBaseParameters(originalBase);
+          }
+          if (originalAudio) {
+            this.parameterMappingSystem.setAudioState(originalAudio);
+          }
+          if (originalInteraction) {
+            this.parameterMappingSystem.setInteractionState(originalInteraction);
+          }
+        } catch (error) {
+          console.warn('BaselineCaptureManager: failed to restore parameter mapping state', error);
+        }
+      }
+    }
+
+    return results;
+  }
+
+  async captureSingleBaseline(request, options = {}) {
+    const {
+      systemName,
+      label = systemName,
+      parameters = {},
+      frames = 1,
+      settleMs = options.settleMs ?? 32,
+      targetLayer = options.targetLayer ?? 'content',
+      audioState = null,
+      interactionState = null,
+    } = request;
+
+    if (!systemName) {
+      return null;
+    }
+
+    if (this.engineCoordinator?.ensureEngine) {
+      await this.engineCoordinator.ensureEngine(systemName);
+    }
+
+    if (this.parameterMappingSystem) {
+      if (audioState) {
+        this.parameterMappingSystem.setAudioState(audioState);
+      }
+      if (interactionState) {
+        this.parameterMappingSystem.setInteractionState(interactionState);
+      }
+      this.parameterMappingSystem.setBaseParameters(parameters);
+    }
+
+    const effective = this.parameterMappingSystem
+      ? this.parameterMappingSystem.getEffectiveParameters()
+      : clone(parameters);
+
+    if (typeof this.engineCoordinator?.applyParameters === 'function') {
+      this.engineCoordinator.applyParameters(effective, systemName);
+    }
+
+    if (typeof this.engineCoordinator?.switchEngine === 'function') {
+      const switched = await this.engineCoordinator.switchEngine(systemName);
+      if (!switched) {
+        return null;
+      }
+    }
+
+    const framesToCapture = Number.isFinite(frames) && frames > 0 ? Math.floor(frames) : 1;
+    const captures = [];
+
+    for (let index = 0; index < framesToCapture; index += 1) {
+      const timestamp = this.clock();
+      const framePayload = {
+        baseline: true,
+        label,
+        frameIndex: index,
+      };
+
+      try {
+        this.engineCoordinator?.render?.(timestamp, framePayload);
+      } catch (error) {
+        console.warn(`BaselineCaptureManager: render failed for ${systemName}`, error);
+      }
+
+      const resource = this.resolveCanvasResource(systemName, targetLayer);
+      const snapshot = {
+        frameIndex: index,
+        timestamp,
+        layer: resource?.key ?? targetLayer ?? null,
+        dataUrl: null,
+        pixelBuffer: null,
+      };
+
+      if (resource?.canvas?.toDataURL && options.captureImages !== false) {
+        const mimeType = typeof options.mimeType === 'string' ? options.mimeType : 'image/png';
+        try {
+          snapshot.dataUrl = resource.canvas.toDataURL(mimeType);
+        } catch (error) {
+          console.warn(`BaselineCaptureManager: toDataURL failed for ${systemName}`, error);
+        }
+      }
+
+      if (options.capturePixels && resource?.context?.readPixels) {
+        try {
+          const width = resource.canvas?.width ?? 0;
+          const height = resource.canvas?.height ?? 0;
+          const buffer = new Uint8Array(width * height * 4);
+          resource.context.readPixels(0, 0, width, height, resource.context.RGBA || 0x1908, resource.context.UNSIGNED_BYTE || 0x1401, buffer);
+          snapshot.pixelBuffer = buffer;
+        } catch (error) {
+          console.warn(`BaselineCaptureManager: readPixels failed for ${systemName}`, error);
+        }
+      }
+
+      captures.push(snapshot);
+
+      if (settleMs && settleMs > 0) {
+        await this.delay(settleMs);
+      }
+    }
+
+    return {
+      systemName,
+      label,
+      baseParameters: clone(parameters),
+      effectiveParameters: clone(effective),
+      frames: captures,
+    };
+  }
+
+  resolveCanvasResource(systemName, preferredLayer) {
+    if (!this.canvasPool?.getCanvasResources) {
+      return null;
+    }
+
+    if (preferredLayer !== undefined && preferredLayer !== null) {
+      const preferred = this.canvasPool.getCanvasResources(systemName, preferredLayer);
+      if (preferred) {
+        return preferred;
+      }
+    }
+
+    for (const key of DEFAULT_LAYER_PREFERENCE) {
+      const resource = this.canvasPool.getCanvasResources(systemName, key);
+      if (resource) {
+        return resource;
+      }
+    }
+
+    return null;
+  }
+
+  delay(ms) {
+    if (!Number.isFinite(ms) || ms <= 0) {
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  }
+}
+
+export default BaselineCaptureManager;

--- a/src/core/CanvasManager.js
+++ b/src/core/CanvasManager.js
@@ -1,270 +1,484 @@
 /**
- * Dead Simple Canvas Manager - Just hide/show containers + fresh engines
- * No canvas destruction - HTML canvases stay put, just switch visibility
+ * CanvasResourcePool
+ * ------------------------------------------------------------
+ * Implements the professional canvas lifecycle architecture from the
+ * PROPER_ARCHITECTURE_SOLUTIONS.md document. Each visualisation system
+ * receives a fixed set of layered canvases with persistent WebGL
+ * contexts so mode switches never churn the DOM or lose GPU state.
  */
 
-export class CanvasManager {
-  constructor() {
-    this.currentSystem = null;
-    this.currentEngine = null;
-    this.mainCanvas = null;
+const DEFAULT_SYSTEMS = ['faceted', 'quantum', 'holographic', 'polychora', 'hypercube'];
+const DEFAULT_LAYER_SCHEMAS = {
+  faceted: [
+    { key: 'background', id: 'background-canvas' },
+    { key: 'shadow', id: 'shadow-canvas' },
+    { key: 'content', id: 'content-canvas' },
+    { key: 'highlight', id: 'highlight-canvas' },
+    { key: 'accent', id: 'accent-canvas' },
+  ],
+  quantum: [
+    { key: 'background', id: 'quantum-background-canvas' },
+    { key: 'shadow', id: 'quantum-shadow-canvas' },
+    { key: 'content', id: 'quantum-content-canvas' },
+    { key: 'highlight', id: 'quantum-highlight-canvas' },
+    { key: 'accent', id: 'quantum-accent-canvas' },
+  ],
+  holographic: [
+    { key: 'background', id: 'holo-background-canvas' },
+    { key: 'shadow', id: 'holo-shadow-canvas' },
+    { key: 'content', id: 'holo-content-canvas' },
+    { key: 'highlight', id: 'holo-highlight-canvas' },
+    { key: 'accent', id: 'holo-accent-canvas' },
+  ],
+  polychora: [
+    { key: 'background', id: 'polychora-background-canvas' },
+    { key: 'shadow', id: 'polychora-shadow-canvas' },
+    { key: 'content', id: 'polychora-content-canvas' },
+    { key: 'highlight', id: 'polychora-highlight-canvas' },
+    { key: 'accent', id: 'polychora-accent-canvas' },
+  ],
+  hypercube: [
+    { key: 'content', id: 'hypercube-canvas' },
+    { key: 'accent', id: 'hypercube-accent-canvas' },
+  ],
+};
+
+const DEFAULT_CONTEXT_ATTRIBUTES = {
+  alpha: true,
+  antialias: true,
+  depth: true,
+  stencil: false,
+  preserveDrawingBuffer: false,
+  powerPreference: 'high-performance',
+};
+
+export class CanvasResourcePool {
+  constructor({
+    systems = DEFAULT_SYSTEMS,
+    layerSchemas = DEFAULT_LAYER_SCHEMAS,
+    contextAttributes = DEFAULT_CONTEXT_ATTRIBUTES,
+    resourceManager = null,
+    maxCanvasesPerSystem = 5,
+  } = {}) {
+    this.systems = systems;
+    this.layerSchemas = layerSchemas;
+    this.contextAttributes = contextAttributes;
+    this.resourceManager = resourceManager;
+    this.maxCanvasesPerSystem = maxCanvasesPerSystem;
+
+    this.containerElements = new Map();
+    this.canvases = new Map();
+    this.contextRecords = new Map();
+    this.initializedSystems = new Set();
+    this.resizeHandler = null;
+    this.activeSystem = null;
+    this.initialised = false;
   }
 
-  initialize(canvas) {
-    console.log('🎮 Initializing CanvasManager with canvas:', canvas?.id || 'unknown');
-    this.mainCanvas = canvas;
-
-    // Ensure canvas dimensions are set properly
-    if (canvas) {
-      const rect = canvas.getBoundingClientRect();
-      canvas.width = rect.width || window.innerWidth;
-      canvas.height = rect.height || window.innerHeight;
-      console.log(`📐 Canvas initialized: ${canvas.width}x${canvas.height}`);
-    }
-
-    return this;
-  }
-
-  async switchToSystem(systemName, engineClasses) {
-    console.log(`🔄 DESTROY OLD → CREATE NEW: ${systemName}`);
-    
-    // STEP 1: DESTROY current engine completely
-    if (this.currentEngine) {
-      if (this.currentEngine.setActive) {
-        this.currentEngine.setActive(false);
-      }
-      if (this.currentEngine.destroy) {
-        this.currentEngine.destroy();
-      }
-      console.log('💥 Old engine destroyed');
-    }
-    
-    // STEP 2: DESTROY old WebGL contexts 
-    this.destroyOldWebGLContexts();
-    
-    // STEP 3: DESTROY all canvases + CREATE 5 fresh ones
-    this.destroyAllCanvasesAndCreateFresh(systemName);
-    
-    // STEP 4: CREATE fresh engine
-    const engine = await this.createFreshEngine(systemName, engineClasses);
-    
-    // STEP 5: Start new engine
-    if (engine && engine.setActive) {
-      engine.setActive(true);
-    }
-    
-    this.currentSystem = systemName;
-    this.currentEngine = engine;
-    console.log(`✅ DESTROY → CREATE complete: ${systemName} ready`);
-    return engine;
-  }
-
-  destroyOldWebGLContexts() {
-    console.log('💥 COMPLETE DESTRUCTION: WebGL contexts + old system cleanup...');
-    
-    // STEP 1: Kill all WebGL contexts first
-    const allCanvases = document.querySelectorAll('canvas');
-    let destroyedCount = 0;
-    
-    allCanvases.forEach(canvas => {
-      // Get any existing WebGL context
-      const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
-      if (gl) {
-        // Force context loss
-        const loseContextExt = gl.getExtension('WEBGL_lose_context');
-        if (loseContextExt) {
-          loseContextExt.loseContext();
-          destroyedCount++;
-        }
-      }
-    });
-    
-    // STEP 2: Clear all global engine references (old system cleanup)
-    if (window.engine) {
-      console.log('💥 Clearing window.engine');
-      window.engine = null;
-    }
-    if (window.quantumEngine) {
-      console.log('💥 Clearing window.quantumEngine');
-      window.quantumEngine = null;
-    }
-    if (window.holographicSystem) {
-      console.log('💥 Clearing window.holographicSystem');
-      window.holographicSystem = null;
-    }
-    if (window.polychoraSystem) {
-      console.log('💥 Clearing window.polychoraSystem');
-      window.polychoraSystem = null;
-    }
-    
-    console.log(`💥 DESTRUCTION COMPLETE: ${destroyedCount} WebGL contexts destroyed, all engine refs cleared`);
-  }
-
-  destroyAllCanvasesAndCreateFresh(systemName) {
-    console.log('💥 DESTROYING ALL CANVASES + CREATING 5 FRESH ONES');
-    
-    // STEP 1: DESTROY all existing canvases completely
-    const allCanvases = document.querySelectorAll('canvas');
-    allCanvases.forEach(canvas => canvas.remove());
-    console.log(`💥 Destroyed ${allCanvases.length} old canvases`);
-    
-    // STEP 2: Clear all containers
-    const containers = ['vib34dLayers', 'quantumLayers', 'holographicLayers', 'polychoraLayers'];
-    containers.forEach(containerId => {
-      const container = document.getElementById(containerId);
-      if (container) {
-        container.innerHTML = '';
-        container.style.display = 'none';
-      }
-    });
-    
-    // STEP 3: CREATE 5 fresh canvases for the new system
-    const targetId = systemName === 'faceted' ? 'vib34dLayers' : `${systemName}Layers`;
-    const targetContainer = document.getElementById(targetId);
-    
-    if (!targetContainer) {
-      console.error(`❌ Container ${targetId} not found`);
+  initialize({ initialSystem = null } = {}) {
+    if (this.initialised) {
       return;
     }
-    
-    // Create canvas IDs for this system
-    const canvasIds = this.getCanvasIdsForSystem(systemName);
-    
-    // Create 5 fresh canvases
-    canvasIds.forEach((canvasId, index) => {
-      const canvas = document.createElement('canvas');
-      canvas.id = canvasId;
-      canvas.className = 'visualization-canvas';
-      canvas.style.position = 'absolute';
-      canvas.style.top = '0';
-      canvas.style.left = '0';
-      canvas.style.width = '100%';
-      canvas.style.height = '100%';
-      canvas.style.zIndex = index + 1;
-      
-      // Set canvas dimensions
-      const viewWidth = window.innerWidth;
-      const viewHeight = window.innerHeight;
-      const dpr = Math.min(window.devicePixelRatio || 1, 2);
-      canvas.width = viewWidth * dpr;
-      canvas.height = viewHeight * dpr;
-      
-      targetContainer.appendChild(canvas);
-    });
-    
-    // Show the target container
-    targetContainer.style.display = 'block';
-    targetContainer.style.visibility = 'visible';
-    targetContainer.style.opacity = '1';
-    
-    console.log(`✅ Created 5 fresh canvases for ${systemName}: ${canvasIds.join(', ')}`);
-  }
-  
-  getCanvasIdsForSystem(systemName) {
-    const baseIds = ['background-canvas', 'shadow-canvas', 'content-canvas', 'highlight-canvas', 'accent-canvas'];
-    
-    switch (systemName) {
-      case 'faceted':
-        return baseIds;
-      case 'quantum':
-        return baseIds.map(id => `quantum-${id}`);
-      case 'holographic':
-        return baseIds.map(id => `holo-${id}`);
-      case 'polychora':
-        return baseIds.map(id => `polychora-${id}`);
-      default:
-        return baseIds;
+
+    this.createContainerElements();
+    if (initialSystem && this.systems.includes(initialSystem)) {
+      this.ensureSystem(initialSystem);
+    } else if (this.systems.length > 0) {
+      this.ensureSystem(this.systems[0]);
     }
-  }
-  
-  async createFreshEngine(systemName, engineClasses) {
-    console.log(`🚀 Creating fresh ${systemName} engine`);
-    
-    let engine = null;
-    
-    try {
-      switch(systemName) {
-        case 'faceted':
-          if (engineClasses.VIB34DIntegratedEngine) {
-            engine = new engineClasses.VIB34DIntegratedEngine();
-            window.engine = engine;
-            console.log('✅ Fresh Faceted engine');
-          }
-          break;
-          
-        case 'quantum':
-          if (engineClasses.QuantumEngine) {
-            engine = new engineClasses.QuantumEngine();
-            window.quantumEngine = engine;
-            console.log('✅ Fresh Quantum engine');
-          }
-          break;
-          
-        case 'holographic':
-          if (engineClasses.RealHolographicSystem) {
-            engine = new engineClasses.RealHolographicSystem();
-            window.holographicSystem = engine;
-            console.log('✅ Fresh Holographic engine');
-          }
-          break;
-          
-        case 'polychora':
-          if (engineClasses.NewPolychoraEngine) {
-            engine = new engineClasses.NewPolychoraEngine();
-            window.newPolychoraEngine = engine;
-            console.log('✅ Fresh TRUE 4D Polychora Engine with VIB34D DNA');
-          }
-          break;
-          
-        default:
-          console.error(`❌ Unknown system: ${systemName}`);
-      }
-      
-    } catch (error) {
-      console.error(`💥 Engine creation failed for ${systemName}:`, error);
-      engine = null;
-    }
-    
-    return engine;
+    this.setupResizeHandler();
+    this.initialised = true;
   }
 
   /**
-   * Handle resize for all canvases in the current system
+   * Create DOM containers for each visualisation system. The containers
+   * are layered absolutely so that switching systems is a matter of
+   * toggling visibility rather than destroying/creating nodes.
    */
-  handleResize(width, height) {
-    if (!this.currentSystem) {
-      console.log('📐 No current system to resize');
+  createContainerElements() {
+    const root = document.getElementById('game-container') || document.body;
+
+    this.systems.forEach((systemName) => {
+      const containerId = systemName === 'faceted' ? 'vib34dLayers' : `${systemName}Layers`;
+      let container = document.getElementById(containerId);
+
+      if (!container) {
+        container = document.createElement('div');
+        container.id = containerId;
+        container.className = 'visualization-container';
+        container.style.cssText = `
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          display: none;
+          pointer-events: none;
+        `;
+        root.appendChild(container);
+      }
+
+      this.containerElements.set(systemName, container);
+    });
+  }
+
+  /**
+   * Pre-allocate canvases and WebGL contexts for each system up-front so
+   * runtime transitions simply reuse pooled resources.
+   */
+  preallocateCanvases(systems = this.systems) {
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const { innerWidth: viewWidth, innerHeight: viewHeight } = window;
+
+    systems.forEach((systemName) => {
+      const layerSchemas = this.layerSchemas[systemName] || [];
+      const container = this.containerElements.get(systemName);
+      if (!container) {
+        return;
+      }
+
+      if (this.initializedSystems.has(systemName)) {
+        return;
+      }
+
+      const canvases = [];
+      this.canvases.set(systemName, canvases);
+      const totalLayers = Math.min(Math.max(layerSchemas.length, 1), this.maxCanvasesPerSystem);
+
+      for (let index = 0; index < totalLayers; index += 1) {
+        const schema = layerSchemas[index] || {};
+        const record = this.createCanvas(
+          systemName,
+          schema,
+          index,
+          viewWidth,
+          viewHeight,
+          dpr,
+          container,
+        );
+
+        canvases.push(record);
+        this.prepareContext(record.canvas, systemName, index, record.key);
+      }
+
+      this.initializedSystems.add(systemName);
+    });
+  }
+
+  createCanvas(systemName, schema, layerIndex, viewWidth, viewHeight, dpr, container) {
+    const entry = typeof schema === 'string' ? { key: schema } : { ...schema };
+    const key = entry.key || entry.name || `layer-${layerIndex}`;
+    const explicitId = entry.id;
+    const generatedId = systemName === 'faceted'
+      ? `${key}-canvas`
+      : `${systemName}-${key}-canvas`;
+    const canvasId = explicitId || generatedId;
+
+    let canvas = (canvasId && document.getElementById(canvasId)) || null;
+
+    if (!canvas) {
+      canvas = document.createElement('canvas');
+      if (canvasId) {
+        canvas.id = canvasId;
+      }
+    }
+
+    if (canvas.parentElement !== container) {
+      container.appendChild(canvas);
+    }
+
+    canvas.dataset.visualizerSystem = systemName;
+    canvas.dataset.visualizerLayer = key;
+
+    const className = entry.className || 'visualization-layer';
+    canvas.className = className;
+
+    const style = canvas.style;
+    style.position = entry.position || 'absolute';
+    style.top = entry.top || '0';
+    style.left = entry.left || '0';
+    style.width = entry.width || '100%';
+    style.height = entry.height || '100%';
+    style.zIndex = String(entry.zIndex ?? layerIndex + 1);
+    style.pointerEvents = entry.pointerEvents || 'none';
+
+    canvas.width = viewWidth * dpr;
+    canvas.height = viewHeight * dpr;
+
+    return { canvas, key, layerIndex };
+  }
+
+  prepareContext(canvas, systemName, layerIndex, layerKey = null) {
+    try {
+      const gl = canvas.getContext('webgl2', this.contextAttributes)
+        || canvas.getContext('webgl', this.contextAttributes);
+
+      if (!gl) {
+        console.warn(`CanvasResourcePool: unable to acquire WebGL context for ${systemName} layer ${layerIndex}`);
+        return;
+      }
+
+      const contextId = this.getContextId(systemName, layerIndex);
+      const entry = (this.canvases.get(systemName) || [])
+        .find((record) => record.canvas === canvas || record.layerIndex === layerIndex);
+      const layerKey = entry?.key || this.contextRecords.get(canvas)?.layerKey || null;
+      gl.viewport(0, 0, canvas.width, canvas.height);
+      if (typeof gl.clearColor === 'function') {
+        gl.clearColor(0, 0, 0, 0);
+      }
+
+      const record = {
+        systemName,
+        layerIndex,
+        layerKey,
+        contextId,
+        context: gl,
+      };
+
+      this.contextRecords.set(canvas, record);
+      this.resourceManager?.registerWebGLContext(contextId, gl, { label: `${systemName}:${layerIndex}` });
+
+      if (typeof canvas.addEventListener === 'function') {
+        canvas.addEventListener('webglcontextlost', (event) => {
+          event.preventDefault?.();
+          this.resourceManager?.handleContextLost?.(contextId);
+        });
+
+        canvas.addEventListener('webglcontextrestored', () => {
+          this.recoverContext(canvas, systemName, layerIndex);
+        });
+      }
+    } catch (error) {
+      console.error(`CanvasResourcePool: WebGL context creation failed for ${systemName}`, error);
+    }
+  }
+
+  /**
+   * Switch the active system by hiding the previous container, showing
+   * the next and ensuring all contexts are healthy.
+   */
+  switchToSystem(systemName) {
+    this.ensureSystem(systemName);
+    if (!this.systems.includes(systemName)) {
+      console.warn(`CanvasResourcePool: unknown system ${systemName}`);
       return;
     }
 
-    console.log(`📐 Resizing canvases for ${this.currentSystem}: ${width}x${height}`);
+    if (this.activeSystem === systemName) {
+      return;
+    }
 
-    // Get canvas IDs for current system
-    const canvasIds = this.getCanvasIdsForSystem(this.currentSystem);
-    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    if (this.activeSystem) {
+      const previousContainer = this.containerElements.get(this.activeSystem);
+      if (previousContainer) {
+        previousContainer.style.display = 'none';
+      }
 
-    canvasIds.forEach(canvasId => {
-      const canvas = document.getElementById(canvasId);
-      if (canvas) {
-        // Update canvas dimensions
-        canvas.width = width * dpr;
-        canvas.height = height * dpr;
-        canvas.style.width = '100%';
-        canvas.style.height = '100%';
-
-        // Also notify WebGL context if it exists
-        const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
-        if (gl) {
-          gl.viewport(0, 0, canvas.width, canvas.height);
+      const previousCanvases = this.canvases.get(this.activeSystem) || [];
+      previousCanvases.forEach(({ canvas }) => {
+        const record = this.contextRecords.get(canvas);
+        if (record?.context && typeof record.context.finish === 'function') {
+          record.context.finish();
         }
+      });
+    }
+
+    const targetContainer = this.containerElements.get(systemName);
+    if (targetContainer) {
+      targetContainer.style.display = 'block';
+      targetContainer.style.visibility = 'visible';
+      targetContainer.style.opacity = '1';
+    }
+
+    const targetCanvases = this.canvases.get(systemName) || [];
+    targetCanvases.forEach(({ canvas }) => {
+      const record = this.contextRecords.get(canvas);
+      if (!record) {
+        return;
+      }
+
+      if (!record.context || record.context.isContextLost?.()) {
+        this.recoverContext(canvas, systemName, record.layerIndex);
       }
     });
 
-    // Also resize the current engine if it has a handleResize method
-    if (this.currentEngine && typeof this.currentEngine.handleResize === 'function') {
-      this.currentEngine.handleResize(width, height);
+    this.activeSystem = systemName;
+  }
+
+  recoverContext(canvas, systemName, layerIndex) {
+    try {
+      const gl = canvas.getContext('webgl2', this.contextAttributes)
+        || canvas.getContext('webgl', this.contextAttributes);
+
+      if (!gl) {
+        console.error(`CanvasResourcePool: failed to recover context for ${systemName}`);
+        return;
+      }
+
+      const entry = (this.canvases.get(systemName) || [])
+        .find((record) => record.canvas === canvas || record.layerIndex === layerIndex);
+      const layerKey = entry?.key || this.contextRecords.get(canvas)?.layerKey || null;
+      const contextId = this.getContextId(systemName, layerIndex);
+      gl.viewport(0, 0, canvas.width, canvas.height);
+      if (typeof gl.clearColor === 'function') {
+        gl.clearColor(0, 0, 0, 0);
+      }
+
+      this.contextRecords.set(canvas, {
+        systemName,
+        layerIndex,
+        layerKey,
+        contextId,
+        context: gl,
+      });
+
+      this.resourceManager?.registerWebGLContext(contextId, gl, { label: `${systemName}:${layerIndex}` });
+      console.log(`CanvasResourcePool: WebGL context recovered for ${systemName} layer ${layerIndex}`);
+    } catch (error) {
+      console.error(`CanvasResourcePool: context recovery failed for ${systemName}`, error);
+    }
+  }
+
+  getCanvasResources(systemName, layer = 0) {
+    this.ensureSystem(systemName);
+    const canvases = this.canvases.get(systemName);
+    if (!canvases || canvases.length === 0) {
+      console.error(`CanvasResourcePool: no canvases registered for system ${systemName}`);
+      return null;
     }
 
-    console.log(`✅ Resized ${canvasIds.length} canvases for ${this.currentSystem}`);
+    let entry = null;
+    if (typeof layer === 'string') {
+      entry = canvases.find((item) => item.key === layer);
+    } else {
+      entry = canvases[layer];
+    }
+
+    if (!entry) {
+      console.error(`CanvasResourcePool: invalid canvas request ${systemName} layer ${layer}`);
+      return null;
+    }
+
+    const { canvas, key, layerIndex } = entry;
+    const record = this.contextRecords.get(canvas);
+
+    return {
+      canvas,
+      key,
+      layerIndex,
+      context: record?.context ?? null,
+      contextId: record?.contextId ?? null,
+      isValid: Boolean(record?.context && !record.context.isContextLost?.()),
+    };
+  }
+
+  setupResizeHandler() {
+    if (this.resizeHandler) {
+      return;
+    }
+
+    let resizeTimeout = null;
+    this.resizeHandler = () => {
+      const handler = () => {
+        this.handleResize();
+      };
+
+      if (resizeTimeout) {
+        window.clearTimeout(resizeTimeout);
+      }
+
+      resizeTimeout = window.setTimeout(handler, 100);
+    };
+
+    window.addEventListener('resize', this.resizeHandler);
+  }
+
+  handleResize(width = window.innerWidth, height = window.innerHeight) {
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+    this.canvases.forEach((systemCanvases) => {
+      systemCanvases.forEach(({ canvas }) => {
+        canvas.width = width * dpr;
+        canvas.height = height * dpr;
+        const record = this.contextRecords.get(canvas);
+
+        if (record?.context && !record.context.isContextLost?.()) {
+          record.context.viewport(0, 0, canvas.width, canvas.height);
+        }
+      });
+    });
+
+    console.log(`CanvasResourcePool: resized to ${width}x${height} (DPR ${dpr})`);
+  }
+
+  destroy() {
+    if (this.resizeHandler) {
+      window.removeEventListener('resize', this.resizeHandler);
+      this.resizeHandler = null;
+    }
+
+    this.systems.forEach((systemName) => {
+      this.resetSystem(systemName);
+    });
+
+    this.canvases.clear();
+    this.contextRecords.clear();
+    this.containerElements.clear();
+    this.initializedSystems.clear();
+    this.activeSystem = null;
+    this.initialised = false;
+  }
+
+  cleanup() {
+    this.destroy();
+  }
+
+  getContextId(systemName, layerIndex) {
+    return `${systemName}-layer-${layerIndex}`;
+  }
+
+  ensureSystem(systemName) {
+    if (!this.systems.includes(systemName)) {
+      return;
+    }
+
+    if (this.initializedSystems.has(systemName)) {
+      return;
+    }
+
+    this.preallocateCanvases([systemName]);
+  }
+
+  resetSystem(systemName) {
+    const canvases = this.canvases.get(systemName);
+    if (!canvases) {
+      return;
+    }
+
+    canvases.forEach(({ canvas }) => {
+      const record = this.contextRecords.get(canvas);
+      if (record?.context) {
+        try {
+          this.resourceManager?.unregisterWebGLContext?.(record.contextId);
+          const extension = record.context.getExtension?.('WEBGL_lose_context');
+          extension?.loseContext?.();
+        } catch (error) {
+          console.warn(`CanvasResourcePool: failed to release context for ${systemName}`, error);
+        }
+      }
+
+      if (canvas?.parentElement) {
+        canvas.parentElement.removeChild(canvas);
+      }
+
+      this.contextRecords.delete(canvas);
+    });
+
+    this.canvases.delete(systemName);
+    this.initializedSystems.delete(systemName);
   }
 }
+
+export class CanvasManager extends CanvasResourcePool {}
+
+export default CanvasResourcePool;

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -1,746 +1,104 @@
-/**
- * VIB34D Integrated Holographic Engine
- * Main system controller combining 5-layer holographic rendering
- * with 4D polytopal mathematics and 100 geometric variations
- */
+import { BaseLayeredEngine } from './BaseLayeredEngine.js';
 
-import { IntegratedHolographicVisualizer } from './Visualizer.js';
-import { ParameterManager } from './Parameters.js';
-import { VariationManager } from '../variations/VariationManager.js';
-import { GallerySystem } from '../gallery/GallerySystem.js';
-import { ExportManager } from '../export/ExportManager.js';
-// InteractionHandler removed - each system handles its own interactions
-import { StatusManager } from '../ui/StatusManager.js';
+const FACETED_PALETTE = {
+  background: {
+    hueOffset: -10,
+    saturation: 0.7,
+    lightness: 0.18,
+    mix: 0.8,
+    intensity: 0.9,
+    energyImpact: 0.3,
+    beatImpact: 0.25,
+    energyMix: 0.2,
+  },
+  shadow: {
+    hueOffset: -40,
+    saturation: 0.55,
+    lightness: 0.12,
+    mix: 0.2,
+    intensity: 0.6,
+    energyImpact: 0.15,
+    damageImpact: 0.35,
+  },
+  content: {
+    hueOffset: 0,
+    saturation: 0.85,
+    lightness: 0.28,
+    mix: 0.65,
+    intensity: 1.0,
+    energyImpact: 0.45,
+    beatImpact: 0.55,
+    energyMix: 0.25,
+  },
+  highlight: {
+    hueOffset: 24,
+    saturation: 0.95,
+    lightness: 0.4,
+    mix: 0.7,
+    intensity: 1.15,
+    energyImpact: 0.55,
+    highlightImpact: 0.65,
+    beatImpact: 0.4,
+    energyMix: 0.3,
+  },
+  accent: {
+    hueOffset: 54,
+    hueSpread: 45,
+    saturation: 1.0,
+    lightness: 0.5,
+    mix: 0.85,
+    intensity: 1.2,
+    energyImpact: 0.65,
+    highlightImpact: 0.7,
+    beatImpact: 0.75,
+    energyMix: 0.35,
+  },
+};
 
-export class VIB34DIntegratedEngine {
-    constructor() {
-        // Core system components
-        this.visualizers = [];
-        this.parameterManager = new ParameterManager();
-        this.variationManager = new VariationManager(this); // CRITICAL FIX: Pass this as engine parameter
-        this.gallerySystem = new GallerySystem(this);
-        this.exportManager = new ExportManager(this);
-        // Each system handles its own interactions - no central handler needed
-        this.statusManager = new StatusManager();
-        
-        // Active state for reactivity
-        this.isActive = false;
-        
-        // Conditional reactivity: Use built-in only if ReactivityManager not active
-        this.useBuiltInReactivity = !window.reactivityManager;
-        
-        // Current state
-        this.currentVariation = 0;
-        this.totalVariations = 100; // 30 default + 70 custom
-        
-        // Mouse interaction state
-        this.mouseX = 0.5;
-        this.mouseY = 0.5;
-        this.mouseIntensity = 0.0;
-        this.clickIntensity = 0.0;
-        
-        // Animation state
-        this.time = 0;
-        this.animationId = null;
-        
-        // Initialize system
-        this.init();
+export class VIB34DIntegratedEngine extends BaseLayeredEngine {
+  constructor(options = {}) {
+    super({
+      ...options,
+      palette: FACETED_PALETTE,
+    });
+
+    this.geometryState = {
+      lastGeometry: this.parameters.geometry,
+      rotationInfluence: 0,
+    };
+  }
+
+  getDefaultParameters() {
+    return {
+      ...super.getDefaultParameters(),
+      hue: 210,
+      intensity: 0.6,
+      saturation: 0.85,
+    };
+  }
+
+  onParametersUpdated() {
+    const geometry = this.parameters.geometry ?? 0;
+    if (geometry !== this.geometryState.lastGeometry) {
+      this.geometryState.lastGeometry = geometry;
+      this.geometryState.rotationInfluence = (geometry % 4) / 4;
+      this.effectState.highlight = Math.min(1.2, this.effectState.highlight + 0.25);
     }
-    
-    /**
-     * Initialize the complete VIB34D system
-     */
-    init() {
-        console.log('🌌 Initializing VIB34D Integrated Holographic Engine...');
-        
-        try {
-            this.createVisualizers();
-            this.setupControls();
-            this.setupInteractions();
-            this.loadCustomVariations();
-            this.populateVariationGrid();
-            this.startRenderLoop();
-            
-            this.statusManager.setStatus('VIB34D Engine initialized successfully', 'success');
-            console.log('✅ VIB34D Engine ready');
-        } catch (error) {
-            console.error('❌ Failed to initialize VIB34D Engine:', error);
-            this.statusManager.setStatus('Initialization failed: ' + error.message, 'error');
-        }
-    }
-    
-    /**
-     * Create the 5-layer holographic visualization system
-     */
-    createVisualizers() {
-        const layers = [
-            { id: 'background-canvas', role: 'background', reactivity: 0.5 },
-            { id: 'shadow-canvas', role: 'shadow', reactivity: 0.7 },
-            { id: 'content-canvas', role: 'content', reactivity: 0.9 },
-            { id: 'highlight-canvas', role: 'highlight', reactivity: 1.1 },
-            { id: 'accent-canvas', role: 'accent', reactivity: 1.5 }
-        ];
-        
-        layers.forEach(layer => {
-            const visualizer = new IntegratedHolographicVisualizer(
-                layer.id, 
-                layer.role, 
-                layer.reactivity, 
-                this.currentVariation
-            );
-            this.visualizers.push(visualizer);
-        });
-        
-        console.log('✅ Created 5-layer integrated holographic system');
-    }
-    
-    /**
-     * Set up UI controls and event handlers
-     */
-    setupControls() {
-        // Delegate to UI components
-        this.setupTabSystem();
-        this.setupParameterControls();
-        this.setupGeometryPresets();
-        this.updateDisplayValues();
-    }
-    
-    setupTabSystem() {
-        document.querySelectorAll('.tab-btn').forEach(btn => {
-            btn.addEventListener('click', () => {
-                document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
-                document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
-                
-                btn.classList.add('active');
-                document.getElementById(btn.dataset.tab + '-tab').classList.add('active');
-            });
-        });
-    }
-    
-    setupParameterControls() {
-        const controls = [
-            'variationSlider', 'rot4dXW', 'rot4dYW', 'rot4dZW', 'dimension',
-            'gridDensity', 'morphFactor', 'chaos', 'speed', 'hue'
-        ];
-        
-        controls.forEach(id => {
-            const element = document.getElementById(id);
-            if (element) {
-                element.addEventListener('input', () => this.updateFromControls());
-            }
-        });
-    }
-    
-    setupGeometryPresets() {
-        document.querySelectorAll('[data-geometry]').forEach(btn => {
-            btn.addEventListener('click', () => {
-                document.querySelectorAll('[data-geometry]').forEach(b => b.classList.remove('active'));
-                btn.classList.add('active');
-                this.parameterManager.setGeometry(parseInt(btn.dataset.geometry));
-                this.updateVisualizers();
-                this.updateDisplayValues();
-            });
-        });
-    }
-    
-    /**
-     * Set up mouse/touch interactions
-     */
-    setupInteractions() {
-        if (!this.useBuiltInReactivity) {
-            console.log('🔷 Faceted built-in reactivity DISABLED - ReactivityManager active');
-            return;
-        }
-        
-        console.log('🔷 Setting up Faceted 4D rotation mouse reactivity');
-        this.setup4DRotationReactivity();
-    }
-    
-    setup4DRotationReactivity() {
-        console.log('🔷 Setting up Faceted: 4D rotations + click flash + scroll density');
-        
-        // Color flash animation state
-        this.colorFlashIntensity = 0;
-        this.flashDecay = 0.95;
-        this.scrollDensity = 15; // Base density
-        
-        // Get faceted canvases
-        const facetedCanvases = [
-            'background-canvas', 'shadow-canvas', 'content-canvas',
-            'highlight-canvas', 'accent-canvas'
-        ];
-        
-        facetedCanvases.forEach(canvasId => {
-            const canvas = document.getElementById(canvasId);
-            if (!canvas) return;
-            
-            // Mouse movement -> 4D rotation parameters
-            canvas.addEventListener('mousemove', (e) => {
-                if (!this.isActive) return;
-                
-                const rect = canvas.getBoundingClientRect();
-                const mouseX = (e.clientX - rect.left) / rect.width;
-                const mouseY = (e.clientY - rect.top) / rect.height;
-                
-                this.update4DRotationParameters(mouseX, mouseY);
-            });
-            
-            // Touch movement -> 4D rotation parameters
-            canvas.addEventListener('touchmove', (e) => {
-                if (!this.isActive) return;
-                e.preventDefault();
-                
-                if (e.touches.length > 0) {
-                    const touch = e.touches[0];
-                    const rect = canvas.getBoundingClientRect();
-                    const touchX = (touch.clientX - rect.left) / rect.width;
-                    const touchY = (touch.clientY - rect.top) / rect.height;
-                    
-                    this.update4DRotationParameters(touchX, touchY);
-                }
-            }, { passive: false });
-            
-            // Click -> color flash effect
-            canvas.addEventListener('click', (e) => {
-                if (!this.isActive) return;
-                
-                this.triggerColorFlash();
-            });
-            
-            // Touch tap -> color flash effect
-            canvas.addEventListener('touchend', (e) => {
-                if (!this.isActive) return;
-                
-                this.triggerColorFlash();
-            });
-            
-            // Wheel -> invisible scroll density effect
-            canvas.addEventListener('wheel', (e) => {
-                if (!this.isActive) return;
-                e.preventDefault();
-                
-                this.updateScrollDensity(e.deltaY);
-            }, { passive: false });
-        });
-        
-        // Start color flash animation loop
-        this.startColorFlashLoop();
-    }
-    
-    update4DRotationParameters(x, y) {
-        // Map mouse/touch position to 4D rotation ranges (-6.28 to 6.28)
-        const rotationRange = 6.28 * 2; // Full range is 12.56
-        
-        // X position controls XW and YW planes
-        const rot4dXW = (x - 0.5) * rotationRange; // -6.28 to +6.28
-        const rot4dYW = (x - 0.5) * rotationRange * 0.7; // Slightly different scaling
-        
-        // Y position controls ZW plane  
-        const rot4dZW = (y - 0.5) * rotationRange;
-        
-        // SUBTLE MOUSE HUE CHANGES (fluid, not extreme)
-        if (!this.mouseHue) this.mouseHue = this.scrollHue || 200; // Use current scroll hue or default
-        
-        // Gentle hue shifts based on mouse position (subtle)
-        const hueOffset = (x - 0.5) * 30; // ±15 degree gentle shift
-        const mouseHue = (this.mouseHue + hueOffset) % 360;
-        
-        // Update parameters through the global parameter system
-        if (window.updateParameter) {
-            window.updateParameter('rot4dXW', rot4dXW.toFixed(2));
-            window.updateParameter('rot4dYW', rot4dYW.toFixed(2));
-            window.updateParameter('rot4dZW', rot4dZW.toFixed(2));
-            window.updateParameter('hue', Math.round(mouseHue)); // Gentle hue changes
-        }
-        
-        console.log(`🔷 Smooth 4D + Hue: XW=${rot4dXW.toFixed(2)}, ZW=${rot4dZW.toFixed(2)}, Hue=${Math.round(mouseHue)}`);
-    }
-    
-    triggerColorFlash() {
-        // DRAMATIC BUT FLUID CLICK EFFECT
-        this.colorFlashIntensity = 1.0; // Start at full flash
-        
-        // Additional dramatic parameters that decay back
-        this.clickChaosBoost = 0.8; // Temporary chaos boost
-        this.clickSpeedBoost = 1.5; // Temporary speed boost
-        
-        console.log('💥 Faceted dramatic click: color flash + chaos + speed boost');
-    }
-    
-    updateScrollDensity(deltaY) {
-        // ENHANCED SCROLL: More reactive with hue changes + density
-        const scrollSpeed = 0.8; // More reactive
-        const scrollDirection = deltaY > 0 ? 1 : -1;
-        
-        // Update density
-        this.scrollDensity += scrollDirection * scrollSpeed;
-        this.scrollDensity = Math.max(5, Math.min(100, this.scrollDensity)); // Clamp 5-100
-        
-        // FLUID HUE CYCLING with scroll
-        if (!this.scrollHue) this.scrollHue = 200; // Base blue hue for faceted
-        const hueSpeed = 3; // Smooth hue changes
-        this.scrollHue += scrollDirection * hueSpeed;
-        this.scrollHue = ((this.scrollHue % 360) + 360) % 360; // Keep 0-360 range
-        
-        // Update parameters smoothly
-        if (window.updateParameter) {
-            window.updateParameter('gridDensity', Math.round(this.scrollDensity));
-            window.updateParameter('hue', Math.round(this.scrollHue));
-        }
-        
-        console.log(`🌀 Smooth scroll: Density=${Math.round(this.scrollDensity)}, Hue=${Math.round(this.scrollHue)}`);
-    }
-    
-    startColorFlashLoop() {
-        const flashAnimation = () => {
-            // ENHANCED DRAMATIC FLASH EFFECT (multiple parameters)
-            let hasActiveEffects = false;
-            
-            if (this.colorFlashIntensity > 0.01) {
-                hasActiveEffects = true;
-                
-                // Create flash effect: dip saturation/intensity then boost
-                const flashPhase = this.colorFlashIntensity;
-                
-                // Phase 1 (1.0 -> 0.5): Dip colors
-                // Phase 2 (0.5 -> 0.0): Boost colors back up
-                let saturationMultiplier, intensityMultiplier;
-                
-                if (flashPhase > 0.5) {
-                    // Dip phase - reduce saturation and intensity
-                    const dipAmount = (flashPhase - 0.5) * 2; // 0-1 range
-                    saturationMultiplier = 1.0 - (dipAmount * 0.7); // Dip to 30%
-                    intensityMultiplier = 1.0 - (dipAmount * 0.5); // Dip to 50%
-                } else {
-                    // Boost phase - increase beyond normal
-                    const boostAmount = (0.5 - flashPhase) * 2; // 0-1 range
-                    saturationMultiplier = 1.0 + (boostAmount * 0.5); // Boost to 150%
-                    intensityMultiplier = 1.0 + (boostAmount * 0.3); // Boost to 130%
-                }
-                
-                // Apply flash modulation to base colors
-                const baseSaturation = 0.8;
-                const baseIntensity = 0.5;
-                
-                const flashSaturation = Math.max(0.1, Math.min(1.0, baseSaturation * saturationMultiplier));
-                const flashIntensity = Math.max(0.1, Math.min(1.0, baseIntensity * intensityMultiplier));
-                
-                // Update color parameters
-                if (window.updateParameter) {
-                    window.updateParameter('saturation', flashSaturation.toFixed(2));
-                    window.updateParameter('intensity', flashIntensity.toFixed(2));
-                }
-                
-                // Smooth decay
-                this.colorFlashIntensity *= 0.94; // Slightly slower decay for smoother effect
-            }
-            
-            // DRAMATIC CHAOS BOOST EFFECT (fluid decay)
-            if (this.clickChaosBoost > 0.01) {
-                hasActiveEffects = true;
-                
-                const baseChaos = 0.2; // Default chaos
-                const currentChaos = baseChaos + this.clickChaosBoost;
-                
-                if (window.updateParameter) {
-                    window.updateParameter('chaos', currentChaos.toFixed(2));
-                }
-                
-                // Smooth decay
-                this.clickChaosBoost *= 0.92;
-            }
-            
-            // DRAMATIC SPEED BOOST EFFECT (fluid decay)
-            if (this.clickSpeedBoost > 0.01) {
-                hasActiveEffects = true;
-                
-                const baseSpeed = 1.0; // Default speed
-                const currentSpeed = baseSpeed + this.clickSpeedBoost;
-                
-                if (window.updateParameter) {
-                    window.updateParameter('speed', currentSpeed.toFixed(2));
-                }
-                
-                // Smooth decay
-                this.clickSpeedBoost *= 0.91;
-            }
-            
-            if (this.isActive) {
-                requestAnimationFrame(flashAnimation);
-            }
-        };
-        
-        flashAnimation();
-    }
-    
-    /**
-     * Load custom variations from storage
-     */
-    loadCustomVariations() {
-        this.variationManager.loadCustomVariations();
-    }
-    
-    /**
-     * Populate the variation grid UI
-     */
-    populateVariationGrid() {
-        this.variationManager.populateGrid();
-    }
-    
-    /**
-     * Start the main render loop
-     */
-    startRenderLoop() {
-        if (window.mobileDebug) {
-            window.mobileDebug.log(`🎬 VIB34D Faceted Engine: Starting render loop with ${this.visualizers?.length} visualizers`);
-        }
-        
-        const render = () => {
-            this.time += 0.016; // ~60fps
-            
-            // MVEP-STYLE AUDIO PROCESSING: Each system processes audio in its own render loop
-            // This eliminates the "holographic override" problem and ensures proper audio reactivity
-            // Audio reactivity now handled directly in visualizer render loops
-            
-            this.updateVisualizers();
-            this.animationId = requestAnimationFrame(render);
-        };
-        render();
-        
-        // Log successful start
-        if (window.mobileDebug) {
-            window.mobileDebug.log(`✅ VIB34D Faceted Engine: Render loop started, animationId=${!!this.animationId}`);
-        }
-    }
-    
-    /**
-     * Update all visualizers with current parameters
-     */
-    updateVisualizers() {
-        const params = this.parameterManager.getAllParameters();
-        
-        // Add interaction state
-        params.mouseX = this.mouseX;
-        params.mouseY = this.mouseY;
-        params.mouseIntensity = this.mouseIntensity;
-        params.clickIntensity = this.clickIntensity;
-        params.time = this.time;
-        
-        this.visualizers.forEach(visualizer => {
-            visualizer.updateParameters(params);
-            visualizer.render();
-        });
-        
-        // Decay interaction intensities
-        this.mouseIntensity *= 0.95;
-        this.clickIntensity *= 0.92;
-    }
-    
-    /**
-     * Update parameters from UI controls
-     */
-    updateFromControls() {
-        this.parameterManager.updateFromControls();
-        this.updateDisplayValues();
-    }
-    
-    /**
-     * Update display values in UI
-     */
-    updateDisplayValues() {
-        this.parameterManager.updateDisplayValues();
-    }
-    
-    /**
-     * Navigate to specific variation
-     */
-    setVariation(index) {
-        if (index >= 0 && index < this.totalVariations) {
-            this.currentVariation = index;
-            this.variationManager.applyVariation(index);
-            this.updateDisplayValues();
-            this.updateVisualizers();
-            
-            // Update UI
-            const slider = document.getElementById('variationSlider');
-            if (slider) {
-                slider.value = index;
-            }
-            
-            this.statusManager.setStatus(`Variation ${index + 1} loaded`, 'info');
-        }
-    }
-    
-    /**
-     * Navigation methods
-     */
-    nextVariation() {
-        this.setVariation((this.currentVariation + 1) % this.totalVariations);
-    }
-    
-    previousVariation() {
-        this.setVariation((this.currentVariation - 1 + this.totalVariations) % this.totalVariations);
-    }
-    
-    randomVariation() {
-        const newIndex = Math.floor(Math.random() * this.totalVariations);
-        this.setVariation(newIndex);
-    }
-    
-    /**
-     * Randomize all parameters
-     */
-    randomizeAll() {
-        this.parameterManager.randomizeAll();
-        this.updateDisplayValues();
-        this.updateVisualizers();
-        this.statusManager.setStatus('All parameters randomized', 'info');
-    }
-    
-    /**
-     * Reset to default parameters
-     */
-    resetToDefaults() {
-        this.parameterManager.resetToDefaults();
-        this.updateDisplayValues();
-        this.updateVisualizers();
-        this.statusManager.setStatus('Reset to default parameters', 'info');
-    }
-    
-    /**
-     * Save current state as custom variation
-     */
-    saveAsCustomVariation() {
-        const customIndex = this.variationManager.saveCurrentAsCustom();
-        if (customIndex !== -1) {
-            this.statusManager.setStatus(`Saved as custom variation ${customIndex + 1}`, 'success');
-            this.populateVariationGrid();
-        } else {
-            this.statusManager.setStatus('All custom slots are full', 'warning');
-        }
-    }
-    
-    /**
-     * Open gallery view
-     */
-    openGalleryView() {
-        this.gallerySystem.openGallery();
-    }
-    
-    /**
-     * Export methods
-     */
-    exportJSON() {
-        this.exportManager.exportJSON();
-    }
-    
-    exportCSS() {
-        this.exportManager.exportCSS();
-    }
-    
-    exportHTML() {
-        this.exportManager.exportHTML();
-    }
-    
-    exportPNG() {
-        this.exportManager.exportPNG();
-    }
-    
-    /**
-     * Import methods
-     */
-    importJSON() {
-        this.exportManager.importJSON();
-    }
-    
-    importFolder() {
-        this.exportManager.importFolder();
-    }
-    
-    /**
-     * Set active state - required by CanvasManager
-     */
-    setActive(active) {
-        console.log(`🔷 Faceted Engine setActive: ${active}`);
-        this.isActive = active; // Set active state for interactions
-        
-        if (active && !this.animationId) {
-            console.log('🎬 Faceted Engine: Starting animation loop');
-            this.startRenderLoop();
-        } else if (!active && this.animationId) {
-            console.log('⏹️ Faceted Engine: Stopping animation loop');
-            cancelAnimationFrame(this.animationId);
-            this.animationId = null;
-        }
-    }
-    
-    /**
-     * Update mouse interaction state
-     */
-    updateInteraction(x, y, intensity = 0.5) {
-        this.mouseX = x;
-        this.mouseY = y;
-        this.mouseIntensity = intensity;
-        
-        // Apply to all faceted visualizers
-        this.visualizers.forEach(visualizer => {
-            if (visualizer.updateInteraction) {
-                visualizer.updateInteraction(x, y, intensity);
-            }
-        });
-    }
-    
-    /**
-     * Trigger click interaction
-     */
-    triggerClick(intensity = 1.0) {
-        this.clickIntensity = intensity;
-    }
-    
-    /**
-     * Update audio reactivity (for universal reactivity system)
-     */
-    // Audio reactivity now handled directly in visualizer render loops - no engine coordination needed
-    
-    /**
-     * Apply audio reactivity grid settings (similar to holographic system)
-     */
-    applyAudioReactivityGrid(audioData) {
-        const settings = this.audioReactivitySettings || window.audioReactivitySettings;
-        if (!settings) return;
-        
-        // Get sensitivity multiplier
-        const sensitivityMultiplier = settings.sensitivity[settings.activeSensitivity];
-        
-        // Apply audio changes to different visual modes based on grid selection
-        settings.activeVisualModes.forEach(modeKey => {
-            const [sensitivity, visualMode] = modeKey.split('-');
-            
-            if (visualMode === 'color') {
-                // COLOR MODE: Affect hue, saturation, intensity
-                const audioIntensity = (audioData.energy * sensitivityMultiplier);
-                const bassIntensity = (audioData.bass * sensitivityMultiplier);
-                const rhythmIntensity = (audioData.rhythm * sensitivityMultiplier);
-                
-                // Modulate hue based on audio frequency spread
-                if (audioData.mid > 0.2) {
-                    const currentHue = this.parameterManager.getParameter('hue') || 180;
-                    const hueShift = audioData.mid * sensitivityMultiplier * 30;
-                    this.parameterManager.setParameter('hue', (currentHue + hueShift) % 360);
-                }
-                
-                // Boost intensity on energy spikes
-                if (audioIntensity > 0.3) {
-                    this.parameterManager.setParameter('intensity', Math.min(1.0, 0.5 + audioIntensity * 0.8));
-                }
-                
-                // Boost saturation on bass hits
-                if (bassIntensity > 0.4) {
-                    this.parameterManager.setParameter('saturation', Math.min(1.0, 0.7 + bassIntensity * 0.3));
-                }
-                
-            } else if (visualMode === 'geometry') {
-                // GEOMETRY MODE: Affect morphFactor, gridDensity, chaos
-                const bassIntensity = (audioData.bass * sensitivityMultiplier);
-                const highIntensity = (audioData.high * sensitivityMultiplier);
-                
-                // Bass affects grid density
-                if (bassIntensity > 0.3) {
-                    const currentDensity = this.parameterManager.getParameter('gridDensity') || 15;
-                    this.parameterManager.setParameter('gridDensity', Math.min(100, currentDensity + bassIntensity * 25));
-                }
-                
-                // Mid frequencies affect morph factor
-                if (audioData.mid > 0.2) {
-                    const morphBoost = audioData.mid * sensitivityMultiplier * 0.5;
-                    this.parameterManager.setParameter('morphFactor', Math.min(2.0, morphBoost));
-                }
-                
-                // High frequencies add chaos
-                if (highIntensity > 0.4) {
-                    this.parameterManager.setParameter('chaos', Math.min(1.0, highIntensity * 0.6));
-                }
-                
-            } else if (visualMode === 'movement') {
-                // MOVEMENT MODE: Affect speed, 4D rotations
-                const energyIntensity = (audioData.energy * sensitivityMultiplier);
-                
-                // Energy affects animation speed
-                if (energyIntensity > 0.2) {
-                    this.parameterManager.setParameter('speed', Math.min(3.0, 0.5 + energyIntensity * 1.5));
-                }
-                
-                // Audio frequencies affect 4D rotations
-                if (audioData.bass > 0.3) {
-                    const currentXW = this.parameterManager.getParameter('rot4dXW') || 0;
-                    this.parameterManager.setParameter('rot4dXW', currentXW + audioData.bass * sensitivityMultiplier * 0.1);
-                }
-                
-                if (audioData.mid > 0.3) {
-                    const currentYW = this.parameterManager.getParameter('rot4dYW') || 0;
-                    this.parameterManager.setParameter('rot4dYW', currentYW + audioData.mid * sensitivityMultiplier * 0.08);
-                }
-                
-                if (audioData.high > 0.3) {
-                    const currentZW = this.parameterManager.getParameter('rot4dZW') || 0;
-                    this.parameterManager.setParameter('rot4dZW', currentZW + audioData.high * sensitivityMultiplier * 0.06);
-                }
-            }
-        });
-    }
-    
-    /**
-     * Update click effects (for universal reactivity system)
-     */
-    updateClick(intensity) {
-        // Trigger click intensity on all visualizers
-        this.clickIntensity = Math.min(1.0, this.clickIntensity + intensity);
-        
-        this.visualizers.forEach(visualizer => {
-            if (visualizer.triggerClick) {
-                visualizer.triggerClick(intensity);
-            }
-        });
-    }
-    
-    /**
-     * Update scroll effects (for universal reactivity system)
-     */
-    updateScroll(velocity) {
-        this.visualizers.forEach(visualizer => {
-            if (visualizer.updateScroll) {
-                visualizer.updateScroll(velocity);
-            }
-        });
-        
-        // Apply scroll to parameter modulation
-        const scrollIntensity = Math.abs(velocity);
-        if (scrollIntensity > 0.1) {
-            // Temporarily adjust morph factor based on scroll
-            const currentMorph = this.parameterManager.getParameter('morphFactor') || 1.0;
-            this.parameterManager.setParameter('morphFactor', Math.max(0.1, currentMorph + velocity * 0.5));
-        }
-    }
-    
-    /**
-     * Clean up resources
-     */
-    destroy() {
-        // Disconnect from universal reactivity
-        if (window.universalReactivity) {
-            window.universalReactivity.disconnectSystem('faceted');
-        }
-        
-        if (this.animationId) {
-            cancelAnimationFrame(this.animationId);
-        }
-        
-        this.visualizers.forEach(visualizer => {
-            if (visualizer.destroy) {
-                visualizer.destroy();
-            }
-        });
-        
-        console.log('🔄 VIB34D Engine destroyed');
-    }
+  }
+
+  computeLayerUniforms(pipeline, palette) {
+    const uniforms = super.computeLayerUniforms(pipeline, palette);
+    const geometry = this.parameters.geometry ?? 0;
+    const morphFactor = this.parameters.morphFactor ?? 1;
+    const rotationInfluence = this.geometryState.rotationInfluence;
+
+    uniforms.chaos = Math.min(2, uniforms.chaos + geometry * 0.05 + morphFactor * 0.1 + rotationInfluence * 0.35);
+    uniforms.detail = Math.min(1, uniforms.detail + geometry * 0.02);
+    uniforms.morph = Math.min(1, uniforms.morph + rotationInfluence * 0.25);
+    uniforms.mix = Math.min(1, uniforms.mix + (this.audioState.high ?? 0) * 0.15);
+
+    return uniforms;
+  }
 }
+
+export default VIB34DIntegratedEngine;

--- a/src/core/EngineCoordinator.js
+++ b/src/core/EngineCoordinator.js
@@ -1,0 +1,572 @@
+/**
+ * EngineCoordinator
+ * ------------------------------------------------------------
+ * Implements the orchestration layer detailed in
+ * PROPER_ARCHITECTURE_SOLUTIONS.md. Engines are initialised in a
+ * deterministic order, share pooled GPU resources and expose lifecycle
+ * hooks for activation, deactivation and recovery.
+ */
+
+const DEFAULT_ENGINE_CONFIG = {
+  faceted: {
+    requiredLayers: ['background', 'shadow', 'content', 'highlight', 'accent'],
+    resourceRequirements: {
+      buffers: ['screen_quad'],
+      shaders: ['common_vertex', 'common_fragment'],
+      textures: ['white_pixel', 'gradient_lut'],
+    },
+    initializationOrder: 1,
+  },
+  quantum: {
+    requiredLayers: ['background', 'shadow', 'content', 'highlight', 'accent'],
+    resourceRequirements: {
+      buffers: ['screen_quad', 'particle_stream'],
+      shaders: ['quantum_vertex', 'quantum_fragment'],
+      textures: ['noise_3d'],
+    },
+    initializationOrder: 2,
+  },
+  holographic: {
+    requiredLayers: ['background', 'shadow', 'content', 'highlight', 'accent'],
+    resourceRequirements: {
+      buffers: ['screen_quad'],
+      shaders: ['holographic_vertex', 'holographic_fragment'],
+      textures: ['gradient_lut'],
+    },
+    initializationOrder: 3,
+  },
+  polychora: {
+    requiredLayers: ['background', 'shadow', 'content', 'highlight', 'accent'],
+    resourceRequirements: {
+      buffers: ['screen_quad', 'unit_cube'],
+      shaders: ['polytope_vertex', 'polytope_fragment'],
+      textures: ['white_pixel'],
+    },
+    initializationOrder: 4,
+  },
+};
+
+export class EngineCoordinator {
+  constructor(canvasPool, { resourceManager = null, stateManager = null } = {}) {
+    this.canvasPool = canvasPool;
+    this.resourceManager = resourceManager;
+    this.stateManager = stateManager;
+
+    this.engineClasses = new Map();
+    this.engineConfigs = new Map();
+    this.engines = new Map();
+    this.sharedResources = new Map();
+    this.engineResourceUsage = new Map();
+    this.engineSnapshots = new Map();
+    this.activeEngine = null;
+    this.transitionState = 'idle';
+
+    Object.entries(DEFAULT_ENGINE_CONFIG).forEach(([system, config]) => {
+      this.engineConfigs.set(system, { ...config });
+    });
+  }
+
+  registerEngine(systemName, EngineClass, overrides = {}) {
+    if (!EngineClass) {
+      return;
+    }
+
+    this.engineClasses.set(systemName, EngineClass);
+    const currentConfig = this.engineConfigs.get(systemName) || {};
+    this.engineConfigs.set(systemName, { ...currentConfig, ...overrides });
+  }
+
+  async initialize({ initialSystem = null } = {}) {
+    const orderedSystems = this.getOrderedSystems();
+    const defaultSystem = (initialSystem && this.engineClasses.has(initialSystem))
+      ? initialSystem
+      : orderedSystems[0] || null;
+
+    if (defaultSystem) {
+      this.canvasPool?.ensureSystem?.(defaultSystem);
+    }
+
+    await this.initializeSharedResources(defaultSystem ? [defaultSystem] : []);
+
+    if (defaultSystem) {
+      await this.ensureEngine(defaultSystem);
+    }
+  }
+
+  getOrderedSystems() {
+    return [...this.engineConfigs.entries()]
+      .sort((a, b) => (a[1].initializationOrder ?? 0) - (b[1].initializationOrder ?? 0))
+      .map(([systemName]) => systemName);
+  }
+
+  async ensureEngine(systemName) {
+    if (this.engines.has(systemName)) {
+      return this.engines.get(systemName);
+    }
+
+    if (!this.engineClasses.has(systemName)) {
+      return null;
+    }
+
+    this.canvasPool?.ensureSystem?.(systemName);
+    const engineInstance = await this.initializeEngine(systemName);
+    if (engineInstance) {
+      this.engines.set(systemName, engineInstance);
+    }
+    return engineInstance;
+  }
+
+  async initializeEngine(systemName) {
+    const EngineClass = this.engineClasses.get(systemName);
+    const config = this.engineConfigs.get(systemName);
+    if (!EngineClass || !config) {
+      return null;
+    }
+
+    const canvasResources = this.getEngineCanvasResources(systemName, config);
+    const instance = new EngineClass({
+      canvasResources,
+      sharedResources: this.sharedResources,
+      resourceManager: this.resourceManager,
+      systemName,
+      config,
+    });
+
+    if (typeof instance.attachSharedResources === 'function') {
+      try {
+        instance.attachSharedResources(this.sharedResources, config?.resourceRequirements || {});
+      } catch (error) {
+        console.error(`EngineCoordinator: failed to attach shared resources for ${systemName}`, error);
+      }
+    }
+
+    if (typeof instance.initialize === 'function') {
+      await instance.initialize();
+    }
+
+    this.validateEngineInterface(instance, systemName);
+
+    if (typeof instance.setActive === 'function') {
+      instance.setActive(false);
+    }
+
+    this.registerResourceUsage(systemName, config);
+
+    return instance;
+  }
+
+  getEngineCanvasResources(systemName, config) {
+    const resources = {};
+    const layers = config?.requiredLayers || [];
+
+    layers.forEach((layerName, index) => {
+      const resource = this.canvasPool.getCanvasResources(systemName, layerName ?? index);
+      if (!resource?.isValid) {
+        throw new Error(`EngineCoordinator: invalid canvas resource for ${systemName} layer ${layerName}`);
+      }
+      resources[layerName] = resource;
+    });
+
+    return resources;
+  }
+
+  async initializeSharedResources(preferredSystems = []) {
+    if (this.sharedResources.size > 0 || !this.resourceManager) {
+      return;
+    }
+
+    const candidates = [...new Set([...preferredSystems, ...this.getOrderedSystems()])];
+    let seed = null;
+
+    for (const systemName of candidates) {
+      const resource = this.canvasPool?.getCanvasResources(systemName, 'background');
+      if (resource?.contextId) {
+        seed = resource;
+        break;
+      }
+    }
+
+    if (!seed?.contextId) {
+      console.warn('EngineCoordinator: unable to build shared resources (no context)');
+      return;
+    }
+
+    const buffers = new Map();
+    const textures = new Map();
+    const shaders = new Map();
+
+    try {
+      const quadBuffer = this.resourceManager.createBuffer(seed.contextId, new Float32Array([
+        -1, -1, 0, 0,
+        1, -1, 1, 0,
+        -1, 1, 0, 1,
+        1, 1, 1, 1,
+      ]));
+      buffers.set('screen_quad', {
+        id: quadBuffer.id,
+        buffer: quadBuffer.handle,
+        handle: quadBuffer.handle,
+        stride: 16,
+        vertexCount: 4,
+        metadata: quadBuffer.metadata,
+      });
+
+      const unitCube = this.resourceManager.createBuffer(seed.contextId, new Float32Array([
+        -1, -1, -1,
+        1, -1, -1,
+        1, 1, -1,
+        -1, 1, -1,
+        -1, -1, 1,
+        1, -1, 1,
+        1, 1, 1,
+        -1, 1, 1,
+      ]));
+      buffers.set('unit_cube', {
+        id: unitCube.id,
+        buffer: unitCube.handle,
+        handle: unitCube.handle,
+        stride: 12,
+        vertexCount: 8,
+        metadata: unitCube.metadata,
+      });
+
+      const whitePixel = this.resourceManager.createTexture(seed.contextId, {
+        width: 1,
+        height: 1,
+        data: new Uint8Array([255, 255, 255, 255]),
+      });
+      textures.set('white_pixel', whitePixel);
+
+      const gradient = this.resourceManager.createGradientTexture(seed.contextId);
+      textures.set('gradient_lut', gradient);
+
+      const noise = this.resourceManager.createNoiseTexture(seed.contextId, 64);
+      textures.set('noise_3d', noise);
+
+      const commonShaders = this.resourceManager.createShaderSuite(seed.contextId, {
+        common_vertex: this.getCommonVertexShader(),
+        common_fragment: this.getCommonFragmentShader(),
+      });
+      commonShaders.forEach((value, key) => shaders.set(key, value));
+    } catch (error) {
+      console.error('EngineCoordinator: failed to initialise shared resources', error);
+    }
+
+    this.sharedResources.set('buffers', buffers);
+    this.sharedResources.set('textures', textures);
+    this.sharedResources.set('shaders', shaders);
+  }
+
+  registerResourceUsage(systemName, config) {
+    if (!this.resourceManager || !config?.resourceRequirements) {
+      return;
+    }
+
+    const requirements = config.resourceRequirements;
+    const resourceIds = [];
+
+    Object.entries(requirements).forEach(([type, keys]) => {
+      const shared = this.sharedResources.get(type);
+      if (!shared) {
+        return;
+      }
+
+      keys.forEach((key) => {
+        const resource = shared.get(key);
+        const resourceId = resource?.id;
+        if (!resourceId) {
+          return;
+        }
+
+        this.resourceManager.attachResourceToUser(resourceId, systemName);
+        resourceIds.push(resourceId);
+      });
+    });
+
+    if (resourceIds.length > 0) {
+      this.engineResourceUsage.set(systemName, resourceIds);
+    }
+  }
+
+  detachResourceUsage(systemName) {
+    if (!this.resourceManager) {
+      return;
+    }
+
+    const resourceIds = this.engineResourceUsage.get(systemName);
+    if (!resourceIds || resourceIds.length === 0) {
+      return;
+    }
+
+    resourceIds.forEach((resourceId) => {
+      this.resourceManager.detachResourceFromUser(resourceId, systemName);
+    });
+    this.engineResourceUsage.delete(systemName);
+  }
+
+  validateEngineInterface(engine, systemName) {
+    const requiredMethods = ['render', 'setActive', 'handleResize'];
+    requiredMethods.forEach((method) => {
+      if (typeof engine[method] !== 'function') {
+        throw new Error(`EngineCoordinator: engine ${systemName} missing method ${method}`);
+      }
+    });
+  }
+
+  getEngine(systemName) {
+    return this.engines.get(systemName) || null;
+  }
+
+  getActiveSystem() {
+    return this.activeEngine || null;
+  }
+
+  async switchEngine(targetSystemName) {
+    if (this.transitionState !== 'idle') {
+      console.warn('EngineCoordinator: transition already in progress');
+      return false;
+    }
+
+    if (!this.engineClasses.has(targetSystemName)) {
+      console.error(`EngineCoordinator: engine ${targetSystemName} is not registered`);
+      return false;
+    }
+
+    const nextEngineInstance = await this.ensureEngine(targetSystemName);
+    if (!nextEngineInstance) {
+      console.error(`EngineCoordinator: failed to prepare engine ${targetSystemName}`);
+      return false;
+    }
+
+    if (this.activeEngine === targetSystemName) {
+      return true;
+    }
+
+    this.transitionState = 'transitioning';
+
+    try {
+      const previousEngine = this.activeEngine;
+      if (previousEngine) {
+        await this.deactivateEngine(previousEngine);
+      }
+
+      this.canvasPool?.switchToSystem(targetSystemName);
+
+      await this.activateEngine(nextEngineInstance, targetSystemName);
+      this.activeEngine = targetSystemName;
+      this.transitionState = 'idle';
+
+      this.stateManager?.dispatch?.({
+        type: 'visualization/switchSystem',
+        payload: targetSystemName,
+      });
+
+      if (previousEngine && previousEngine !== targetSystemName) {
+        this.releaseEngine(previousEngine);
+      }
+
+      return true;
+    } catch (error) {
+      console.error(`EngineCoordinator: failed to switch to ${targetSystemName}`, error);
+      this.transitionState = 'error';
+      return false;
+    }
+  }
+
+  async deactivateEngine(systemName) {
+    const engine = this.engines.get(systemName);
+    if (!engine) {
+      return;
+    }
+
+    engine.setActive?.(false);
+    await engine.deactivate?.();
+
+    if (typeof engine.saveState === 'function') {
+      try {
+        const snapshot = await engine.saveState();
+        if (snapshot !== undefined) {
+          this.engineSnapshots.set(systemName, snapshot);
+        }
+      } catch (error) {
+        console.warn(`EngineCoordinator: saveState failed for ${systemName}`, error);
+      }
+    }
+  }
+
+  releaseEngine(systemName) {
+    const engine = this.engines.get(systemName);
+    if (!engine) {
+      return;
+    }
+
+    try {
+      engine.destroy?.();
+    } catch (error) {
+      console.warn(`EngineCoordinator: destroy failed for ${systemName}`, error);
+    }
+
+    this.detachResourceUsage(systemName);
+    this.engines.delete(systemName);
+    this.engineSnapshots.delete(systemName);
+    this.canvasPool?.resetSystem?.(systemName);
+  }
+
+  async activateEngine(engine, systemName) {
+    if (!engine) {
+      return;
+    }
+
+    await engine.restoreState?.();
+    engine.handleResize?.(window.innerWidth, window.innerHeight);
+    engine.setActive?.(true);
+  }
+
+  applyParameters(parameters, systemName = this.activeEngine) {
+    if (!systemName || !this.engines.has(systemName)) {
+      return;
+    }
+
+    const engine = this.engines.get(systemName);
+    if (typeof engine.setParameters === 'function') {
+      engine.setParameters(parameters);
+      return;
+    }
+
+    if (engine.parameterManager?.setParameters) {
+      engine.parameterManager.setParameters(parameters);
+      return;
+    }
+
+    engine.updateParameters?.(parameters);
+  }
+
+  render(timestamp, framePayload) {
+    if (this.transitionState !== 'idle' || !this.activeEngine) {
+      return;
+    }
+
+    const engine = this.engines.get(this.activeEngine);
+    if (!engine) {
+      return;
+    }
+
+    try {
+      engine.render(timestamp, framePayload);
+    } catch (error) {
+      console.error(`EngineCoordinator: render error in ${this.activeEngine}`, error);
+      this.handleRenderingError(this.activeEngine, error);
+    }
+  }
+
+  broadcast(methodName, ...args) {
+    if (!methodName) {
+      return false;
+    }
+
+    let handled = false;
+
+    this.engines.forEach((engine, systemName) => {
+      const fn = engine?.[methodName];
+      if (typeof fn !== 'function') {
+        return;
+      }
+
+      try {
+        fn.apply(engine, args);
+        handled = true;
+      } catch (error) {
+        console.error(`EngineCoordinator: broadcast ${methodName} failed for ${systemName}`, error);
+      }
+    });
+
+    return handled;
+  }
+
+  handleRenderingError(systemName, error) {
+    const resource = this.canvasPool.getCanvasResources(systemName, 'background');
+    if (resource?.context?.isContextLost?.()) {
+      console.warn(`EngineCoordinator: context lost for ${systemName}, recovery will be attempted by the pool`);
+      return;
+    }
+
+    const engine = this.engines.get(systemName);
+    engine?.setActive?.(false);
+    engine?.destroy?.();
+    this.detachResourceUsage(systemName);
+    this.engines.delete(systemName);
+  }
+
+  resize(width, height) {
+    this.canvasPool?.handleResize(width, height);
+    this.engines.forEach((engine) => {
+      engine?.handleResize?.(width, height);
+    });
+  }
+
+  destroy() {
+    this.engines.forEach((engine, systemName) => {
+      try {
+        engine?.setActive?.(false);
+        this.detachResourceUsage(systemName);
+        engine?.destroy?.();
+      } catch (error) {
+        console.error(`EngineCoordinator: failed to destroy engine ${systemName}`, error);
+      }
+    });
+
+    this.engines.clear();
+    this.activeEngine = null;
+    this.transitionState = 'idle';
+
+    this.sharedResources.forEach((resourceMap, type) => {
+      if (!this.resourceManager) {
+        return;
+      }
+
+      resourceMap.forEach((resource, key) => {
+        try {
+          this.resourceManager.releaseSharedResource?.(type, key, resource);
+        } catch (error) {
+          console.error(`EngineCoordinator: failed to release shared resource ${type}:${key}`, error);
+        }
+      });
+    });
+
+    this.sharedResources.clear();
+  }
+
+  getCommonVertexShader() {
+    return `
+      attribute vec3 a_position;
+      attribute vec2 a_texcoord;
+
+      varying vec2 v_texcoord;
+
+      uniform mat4 u_mvpMatrix;
+
+      void main() {
+        v_texcoord = a_texcoord;
+        gl_Position = u_mvpMatrix * vec4(a_position, 1.0);
+      }
+    `;
+  }
+
+  getCommonFragmentShader() {
+    return `
+      precision highp float;
+
+      varying vec2 v_texcoord;
+
+      uniform sampler2D u_gradient;
+      uniform float u_time;
+
+      void main() {
+        vec4 base = texture2D(u_gradient, vec2(v_texcoord.x, fract(u_time * 0.1)));
+        gl_FragColor = vec4(base.rgb, 1.0);
+      }
+    `;
+  }
+}
+
+export default EngineCoordinator;

--- a/src/core/ParameterMappingSystem.js
+++ b/src/core/ParameterMappingSystem.js
@@ -1,0 +1,402 @@
+/**
+ * ParameterMappingSystem
+ * ------------------------------------------------------------
+ * Combines base visualization parameters with real-time audio and
+ * interaction data so that engines receive "effective" uniforms
+ * aligned with the architectural guidance captured in
+ * COMPREHENSIVE_ARCHITECTURE_ANALYSIS.md and
+ * PROPER_ARCHITECTURE_SOLUTIONS.md. The mapper keeps base parameters
+ * intact for persistence/state management while deriving responsive
+ * values for rendering.
+ */
+
+const DEFAULT_PARAMETER_BOUNDS = {
+  geometry: { min: 0, max: 7 },
+  gridDensity: { min: 4, max: 100 },
+  morphFactor: { min: 0, max: 2 },
+  chaos: { min: 0, max: 1 },
+  speed: { min: 0.1, max: 3 },
+  hue: { min: 0, max: 360 },
+  intensity: { min: 0, max: 1 },
+  saturation: { min: 0, max: 1 },
+  dimension: { min: 3, max: 4.5 },
+  rot4dXW: { min: -2, max: 2 },
+  rot4dYW: { min: -2, max: 2 },
+  rot4dZW: { min: -2, max: 2 },
+};
+
+const PERF = typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+  ? performance
+  : { now: () => Date.now() };
+
+function clamp(value, min, max) {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+  if (min !== undefined && value < min) {
+    return min;
+  }
+  if (max !== undefined && value > max) {
+    return max;
+  }
+  return value;
+}
+
+function wrap(value, min, max) {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+  const range = max - min;
+  if (range <= 0) {
+    return clamp(value, min, max);
+  }
+  let result = value;
+  while (result < min) {
+    result += range;
+  }
+  while (result > max) {
+    result -= range;
+  }
+  return result;
+}
+
+function resolvePath(source, path = []) {
+  if (!source || !Array.isArray(path) || path.length === 0) {
+    return undefined;
+  }
+  return path.reduce((acc, key) => (acc && acc[key] !== undefined ? acc[key] : undefined), source);
+}
+
+function shallowEqual(a, b) {
+  if (a === b) {
+    return true;
+  }
+  const keysA = Object.keys(a || {});
+  const keysB = Object.keys(b || {});
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+  return keysA.every((key) => Object.is(a[key], b[key]));
+}
+
+function createDefaultInteractionState() {
+  const now = PERF.now();
+  return {
+    mouseMovement: {
+      normalizedX: 0.5,
+      normalizedY: 0.5,
+      velocity: 0,
+      lastTimestamp: now,
+    },
+    scroll: {
+      lastDelta: 0,
+      lastTimestamp: 0,
+    },
+    clickHold: {
+      lastIntensity: 0,
+      lastTimestamp: 0,
+    },
+    pattern: {
+      type: 'none',
+    },
+    meta: {
+      lastInteractionTimestamp: now,
+    },
+  };
+}
+
+function computeDecay(value, timestamp, halfLifeMs, now = PERF.now()) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  if (!Number.isFinite(timestamp) || halfLifeMs <= 0) {
+    return clamp(value, 0, 1);
+  }
+  const elapsed = Math.max(0, now - timestamp);
+  if (elapsed <= 0) {
+    return clamp(value, 0, 1);
+  }
+  const decayFactor = Math.pow(0.5, elapsed / halfLifeMs);
+  return clamp(value * decayFactor, 0, 1);
+}
+
+const DEFAULT_MAPPINGS = [
+  {
+    targetParameter: 'gridDensity',
+    source: { type: 'audio', key: 'bass' },
+    map: (base, bass) => base + bass * 30,
+    clamp: { min: 4, max: 100 },
+  },
+  {
+    targetParameter: 'morphFactor',
+    source: { type: 'audio', key: 'mid' },
+    map: (base, mid) => base + mid * 0.7,
+    clamp: { min: 0, max: 2 },
+  },
+  {
+    targetParameter: 'speed',
+    source: { type: 'audio', key: 'energy' },
+    map: (base, energy) => base * (0.8 + energy * 0.6),
+    clamp: { min: 0.1, max: 3 },
+  },
+  {
+    targetParameter: 'chaos',
+    source: { type: 'interaction', path: ['idle', 'decayFactor'] },
+    map: (base, decayFactor) => base * (0.4 + decayFactor * 0.6),
+    clamp: { min: 0, max: 1 },
+  },
+  {
+    targetParameter: 'hue',
+    source: { type: 'interaction', path: ['mouseMovement', 'normalizedX'] },
+    map: (base, normalizedX) => base + (normalizedX - 0.5) * 120,
+    wrap: { min: 0, max: 360 },
+  },
+  {
+    targetParameter: 'saturation',
+    source: { type: 'interaction', path: ['mouseMovement', 'normalizedY'] },
+    map: (base, normalizedY) => base * (0.6 + (1 - normalizedY) * 0.6),
+    clamp: { min: 0, max: 1 },
+  },
+  {
+    targetParameter: 'dimension',
+    source: { type: 'interaction', path: ['scroll', 'intensity'] },
+    map: (base, scrollIntensity) => base + (scrollIntensity * 0.6 - 0.3),
+    clamp: { min: 3, max: 4.5 },
+  },
+  {
+    targetParameter: 'rot4dZW',
+    source: { type: 'interaction', path: ['clickHold', 'intensity'] },
+    map: (base, clickIntensity) => base + clickIntensity * 1.2,
+    clamp: { min: -2, max: 2 },
+  },
+  {
+    targetParameter: 'intensity',
+    source: { type: 'audio', key: 'high' },
+    map: (base, high) => base + high * 0.4,
+    clamp: { min: 0, max: 1 },
+  },
+];
+
+export class ParameterMappingSystem {
+  constructor(baseParameters = {}, options = {}) {
+    this.parameterBounds = { ...DEFAULT_PARAMETER_BOUNDS, ...(options.parameterBounds || {}) };
+    this.baseParameters = { ...baseParameters };
+    this.effectiveParameters = { ...baseParameters };
+    this.audioState = {
+      bass: 0,
+      mid: 0,
+      high: 0,
+      energy: 0,
+    };
+    this.interactionState = createDefaultInteractionState();
+    this.mappings = Array.isArray(options.mappings) && options.mappings.length > 0
+      ? [...options.mappings]
+      : [...DEFAULT_MAPPINGS];
+  }
+
+  setBaseParameters(baseParameters = {}) {
+    this.baseParameters = { ...baseParameters };
+    return this.updateEffectiveParameters();
+  }
+
+  mergeBaseParameters(partialParameters = {}) {
+    Object.entries(partialParameters).forEach(([key, value]) => {
+      if (value === undefined) {
+        return;
+      }
+      this.baseParameters[key] = value;
+    });
+    return this.updateEffectiveParameters();
+  }
+
+  setAudioState(partialAudioState = {}) {
+    let changed = false;
+    Object.entries(partialAudioState).forEach(([key, value]) => {
+      if (!Object.prototype.hasOwnProperty.call(this.audioState, key) || value === undefined) {
+        return;
+      }
+      const clampedValue = clamp(value, 0, 1);
+      if (!Object.is(this.audioState[key], clampedValue)) {
+        this.audioState[key] = clampedValue;
+        changed = true;
+      }
+    });
+
+    const recomputed = this.updateEffectiveParameters();
+    return changed || recomputed;
+  }
+
+  setInteractionState(nextInteractionState = {}) {
+    if (!nextInteractionState || typeof nextInteractionState !== 'object') {
+      return false;
+    }
+
+    const mergeSection = (target, source) => {
+      if (!source) {
+        return;
+      }
+      Object.entries(source).forEach(([key, value]) => {
+        if (value !== undefined) {
+          if (value && typeof value === 'object' && !Array.isArray(value)) {
+            if (!target[key] || typeof target[key] !== 'object') {
+              target[key] = {};
+            }
+            mergeSection(target[key], value);
+          } else {
+            target[key] = value;
+          }
+        }
+      });
+    };
+
+    mergeSection(this.interactionState, nextInteractionState);
+    return this.updateEffectiveParameters();
+  }
+
+  getEffectiveParameters() {
+    return { ...this.effectiveParameters };
+  }
+
+  getBaseParameters() {
+    return { ...this.baseParameters };
+  }
+
+  getAudioState() {
+    return { ...this.audioState };
+  }
+
+  getInteractionState() {
+    return JSON.parse(JSON.stringify(this.interactionState));
+  }
+
+  updateEffectiveParameters() {
+    const computed = this.computeEffectiveParameters();
+    if (shallowEqual(this.effectiveParameters, computed)) {
+      return false;
+    }
+    this.effectiveParameters = computed;
+    return true;
+  }
+
+  computeEffectiveParameters() {
+    const effective = { ...this.baseParameters };
+    const derivedInteraction = this.getDerivedInteractionState();
+
+    this.mappings.forEach((mapping) => {
+      const baseValue = effective[mapping.targetParameter];
+      if (baseValue === undefined) {
+        return;
+      }
+
+      const primary = this.resolveSource(mapping.source, derivedInteraction);
+      if (primary === undefined) {
+        return;
+      }
+
+      const secondary = this.resolveSource(mapping.secondarySource, derivedInteraction);
+      const context = {
+        audio: this.audioState,
+        interaction: derivedInteraction,
+        base: this.baseParameters,
+      };
+
+      let mappedValue;
+      try {
+        mappedValue = typeof mapping.map === 'function'
+          ? mapping.map(baseValue, primary, secondary, context)
+          : baseValue;
+      } catch (error) {
+        console.warn?.('ParameterMappingSystem: mapping function threw an error', error);
+        mappedValue = baseValue;
+      }
+
+      if (!Number.isFinite(mappedValue)) {
+        return;
+      }
+
+      if (mapping.wrap) {
+        mappedValue = wrap(mappedValue, mapping.wrap.min ?? 0, mapping.wrap.max ?? 1);
+      } else if (mapping.clamp) {
+        mappedValue = clamp(mappedValue, mapping.clamp.min, mapping.clamp.max);
+      } else if (this.parameterBounds[mapping.targetParameter]) {
+        const bounds = this.parameterBounds[mapping.targetParameter];
+        mappedValue = clamp(mappedValue, bounds.min, bounds.max);
+      }
+
+      if (mapping.round === true) {
+        mappedValue = Math.round(mappedValue);
+      }
+
+      effective[mapping.targetParameter] = mappedValue;
+    });
+
+    // Expose audio bands for engines that consume them directly.
+    effective.audioBass = this.audioState.bass;
+    effective.audioMid = this.audioState.mid;
+    effective.audioHigh = this.audioState.high;
+    effective.audioEnergy = this.audioState.energy;
+
+    return effective;
+  }
+
+  resolveSource(sourceDescriptor, derivedInteraction) {
+    if (!sourceDescriptor) {
+      return undefined;
+    }
+
+    if (sourceDescriptor.type === 'audio') {
+      return this.audioState[sourceDescriptor.key];
+    }
+
+    if (sourceDescriptor.type === 'interaction') {
+      if (Array.isArray(sourceDescriptor.path)) {
+        return resolvePath(derivedInteraction, sourceDescriptor.path);
+      }
+      if (sourceDescriptor.key) {
+        return derivedInteraction[sourceDescriptor.key];
+      }
+    }
+
+    return undefined;
+  }
+
+  getDerivedInteractionState() {
+    const now = PERF.now();
+    const state = this.interactionState || {};
+    const mouse = state.mouseMovement || {};
+    const scroll = state.scroll || {};
+    const click = state.clickHold || {};
+    const pattern = state.pattern || {};
+    const lastInteraction = state.meta?.lastInteractionTimestamp || mouse.lastTimestamp || now;
+
+    const velocity = computeDecay(mouse.velocity ?? 0, mouse.lastTimestamp ?? now, 120, now);
+    const scrollIntensity = computeDecay(scroll.lastDelta ?? 0, scroll.lastTimestamp ?? 0, 360, now);
+    const clickIntensity = computeDecay(click.lastIntensity ?? 0, click.lastTimestamp ?? 0, 420, now);
+
+    const idleElapsed = Math.max(0, now - lastInteraction);
+    const idleWindow = 6000; // ms before reaching calm state
+    const idleDecay = clamp(1 - idleElapsed / idleWindow, 0, 1);
+
+    return {
+      mouseMovement: {
+        normalizedX: clamp(mouse.normalizedX ?? 0.5, 0, 1),
+        normalizedY: clamp(mouse.normalizedY ?? 0.5, 0, 1),
+        velocity,
+      },
+      scroll: {
+        intensity: scrollIntensity,
+      },
+      clickHold: {
+        intensity: clickIntensity,
+      },
+      idle: {
+        decayFactor: idleDecay,
+      },
+      pattern: {
+        type: pattern.type || 'none',
+      },
+    };
+  }
+}
+
+export default ParameterMappingSystem;

--- a/src/core/PolychoraSystem.js
+++ b/src/core/PolychoraSystem.js
@@ -1,497 +1,113 @@
-/**
- * VIB34D Polychora System - Complete modular implementation
- * ULTRA PRESERVATION: Every 4D polytope, glassmorphic effect, mathematical function preserved EXACTLY
- */
+import { BaseLayeredEngine } from './BaseLayeredEngine.js';
 
-export class PolychoraSystem {
-    constructor() {
-        this.name = 'polychora';
-        this.isActive = false;
-        this.isInitialized = false;
-        
-        // Canvas management - EXACT same IDs as index.html
-        this.canvasIds = [
-            'polychora-background-canvas',
-            'polychora-shadow-canvas', 
-            'polychora-content-canvas',
-            'polychora-highlight-canvas',
-            'polychora-accent-canvas'
-        ];
-        
-        // Engine and UI components
-        this.engine = null;
-        this.visualizers = [];
-        this.parameters = new Map();
-        
-        // 4D Polytope configuration exactly like index.html
-        this.polytopes = [
-            '5-Cell', 'Tesseract', '16-Cell',
-            '24-Cell', '600-Cell', '120-Cell'
-        ];
-        
-        console.log('🔮 PolychoraSystem: Initialized with true 4D polytope mathematics');
-    }
+const POLYCHORA_PALETTE = {
+  background: {
+    hueOffset: -200,
+    saturation: 0.6,
+    lightness: 0.16,
+    mix: 0.7,
+    intensity: 0.85,
+    energyImpact: 0.4,
+    beatImpact: 0.3,
+    energyMix: 0.3,
+  },
+  shadow: {
+    hueOffset: -230,
+    saturation: 0.5,
+    lightness: 0.1,
+    mix: 0.3,
+    intensity: 0.55,
+    energyImpact: 0.18,
+    damageImpact: 0.4,
+  },
+  content: {
+    hueOffset: -40,
+    saturation: 0.9,
+    lightness: 0.28,
+    mix: 0.75,
+    intensity: 1.05,
+    energyImpact: 0.55,
+    beatImpact: 0.6,
+    highlightImpact: 0.5,
+    energyMix: 0.35,
+  },
+  highlight: {
+    hueOffset: 10,
+    saturation: 1.0,
+    lightness: 0.44,
+    mix: 0.85,
+    intensity: 1.3,
+    energyImpact: 0.7,
+    beatImpact: 0.55,
+    highlightImpact: 0.7,
+    energyMix: 0.45,
+  },
+  accent: {
+    hueOffset: 90,
+    hueSpread: 80,
+    saturation: 1.0,
+    lightness: 0.6,
+    mix: 0.92,
+    intensity: 1.4,
+    energyImpact: 0.75,
+    beatImpact: 0.8,
+    highlightImpact: 0.75,
+    energyMix: 0.5,
+  },
+};
 
-    /**
-     * Initialize the Polychora system - PRESERVE ALL 4D MATHEMATICS
-     */
-    async initialize() {
-        console.log('🔮 PolychoraSystem: Starting initialization with glassmorphic 4D polytopes');
-        
-        try {
-            // Import engine exactly like index.html does
-            const { PolychoraSystem: PolychoraEngine } = await import('../../src/core/PolychoraSystem.js');
-            
-            // CRITICAL: Don't create engine yet - will be created on activation
-            // This preserves the exact behavior of index.html
-            this.PolychoraEngine = PolychoraEngine;
-            
-            // Setup polytope UI exactly like index.html
-            this.setupPolytopes();
-            
-            // Initialize 4D parameters exactly like index.html
-            this.initializeParameters();
-            
-            this.isInitialized = true;
-            console.log('✅ PolychoraSystem: Initialization complete with 4D polytope mathematics');
-            return true;
-        } catch (error) {
-            console.error('❌ PolychoraSystem: Initialization failed:', error);
-            return false;
-        }
-    }
+export class PolychoraSystem extends BaseLayeredEngine {
+  constructor(options = {}) {
+    super({
+      ...options,
+      palette: POLYCHORA_PALETTE,
+    });
 
-    /**
-     * Activate the Polychora system - PRESERVE EXACT 4D MATHEMATICS
-     */
-    async activate() {
-        console.log('🔮 PolychoraSystem: Activating with glassmorphic 4D polytope rendering');
-        
-        try {
-            // Create engine if not exists (exactly like index.html does)
-            if (!this.engine) {
-                await this.createEngine();
-            }
-            
-            // Show canvas layers
-            this.showCanvasLayers();
-            
-            // Activate engine with EXACT parameters from original
-            if (this.engine) {
-                this.engine.isActive = true;
-                
-                // Polychora system may have specific activation method
-                if (this.engine.setActive) {
-                    this.engine.setActive(true);
-                }
-                
-                // Start render loop exactly like index.html
-                if (this.engine.startRenderLoop) {
-                    this.engine.startRenderLoop();
-                } else if (this.engine.render) {
-                    // Start manual render loop for Polychora
-                    this.startRenderLoop();
-                }
-                
-                // Force all visualizers to start rendering - CRITICAL for gallery preview
-                if (this.engine.visualizers) {
-                    this.engine.visualizers.forEach(visualizer => {
-                        if (visualizer && visualizer.gl) {
-                            visualizer.isActive = true;
-                        }
-                    });
-                }
-                
-                // Make globally accessible for gallery/viewer integration
-                window.polychoraSystem = this.engine;
-            }
-            
-            // Update UI state
-            this.updateUI();
-            
-            this.isActive = true;
-            console.log('✅ PolychoraSystem: Activated successfully with glassmorphic 4D polytope rendering');
-            return true;
-        } catch (error) {
-            console.error('❌ PolychoraSystem: Activation failed:', error);
-            return false;
-        }
-    }
+    this.fourDimensionalState = {
+      topologyPulse: 0,
+      rotationDrift: 0,
+    };
+  }
 
-    /**
-     * Deactivate the Polychora system
-     */
-    async deactivate() {
-        console.log('🔮 PolychoraSystem: Deactivating');
-        
-        try {
-            // Stop render loop
-            if (this.renderLoopId) {
-                cancelAnimationFrame(this.renderLoopId);
-                this.renderLoopId = null;
-            }
-            
-            // Deactivate engine
-            if (this.engine) {
-                this.engine.isActive = false;
-                
-                if (this.engine.setActive) {
-                    this.engine.setActive(false);
-                }
-                
-                // Stop render loop
-                if (this.engine.stopRenderLoop) {
-                    this.engine.stopRenderLoop();
-                }
-            }
-            
-            // Hide canvas layers
-            this.hideCanvasLayers();
-            
-            this.isActive = false;
-            console.log('✅ PolychoraSystem: Deactivated successfully');
-            return true;
-        } catch (error) {
-            console.error('❌ PolychoraSystem: Deactivation failed:', error);
-            return false;
-        }
-    }
+  getDefaultParameters() {
+    return {
+      ...super.getDefaultParameters(),
+      hue: 320,
+      intensity: 0.65,
+      saturation: 0.92,
+      dimension: 3.8,
+      chaos: 0.25,
+    };
+  }
 
-    /**
-     * Create engine exactly like index.html does - PRESERVE ALL 4D POLYTOPE EFFECTS
-     */
-    async createEngine() {
-        console.log('🔮 PolychoraSystem: Creating engine with glassmorphic 4D polytope mathematics');
-        
-        try {
-            // Create engine with exact parameters from index.html
-            this.engine = new this.PolychoraEngine();
-            
-            // Initialize the polychora engine
-            const success = this.engine.initialize ? await this.engine.initialize() : true;
-            
-            if (success && this.engine) {
-                // Make visualizers accessible if they exist
-                if (this.engine.visualizers) {
-                    this.visualizers = this.engine.visualizers;
-                } else {
-                    // Polychora might not expose visualizers directly
-                    this.visualizers = [];
-                }
-                
-                // Setup parameter listeners exactly like index.html
-                this.setupParameterListeners();
-                
-                console.log(`✅ PolychoraSystem: Engine created with glassmorphic 4D polytope rendering`);
-                return true;
-            } else {
-                throw new Error('Polychora engine initialization failed');
-            }
-        } catch (error) {
-            console.error('❌ PolychoraSystem: Engine creation failed:', error);
-            this.engine = null;
-            return false;
-        }
-    }
+  onParametersUpdated() {
+    super.onParametersUpdated();
+    const dimension = this.parameters.dimension ?? 3.8;
+    this.fourDimensionalState.rotationDrift = (dimension - 3) / 1.5;
+  }
 
-    /**
-     * Start manual render loop for Polychora system
-     */
-    startRenderLoop() {
-        const renderFrame = () => {
-            if (this.isActive && this.engine && this.engine.render) {
-                try {
-                    this.engine.render();
-                } catch (error) {
-                    console.warn('🔮 PolychoraSystem: Render error:', error);
-                }
-            }
-            
-            if (this.isActive) {
-                this.renderLoopId = requestAnimationFrame(renderFrame);
-            }
-        };
-        
-        this.renderLoopId = requestAnimationFrame(renderFrame);
-        console.log('🔮 PolychoraSystem: Manual render loop started');
-    }
+  onAudioData(audioData = {}) {
+    super.onAudioData(audioData);
+    this.fourDimensionalState.topologyPulse = Math.max(this.fourDimensionalState.topologyPulse, this.audioState.bass * 0.9);
+    this.effectState.chaos = Math.max(this.effectState.chaos, this.audioState.mid * 0.7);
+  }
 
-    /**
-     * Show canvas layers for this system - EXACT layer management
-     */
-    showCanvasLayers() {
-        const layers = document.getElementById('polychoraLayers');
-        if (layers) {
-            layers.style.display = 'block';
-            layers.style.visibility = 'visible';
-            layers.style.opacity = '1';
-            console.log('🔮 PolychoraSystem: Canvas layers visible with glassmorphic 4D effects');
-        }
-    }
+  render(timestamp) {
+    this.effectState.combo = Math.max(this.effectState.combo, this.fourDimensionalState.rotationDrift * 0.4);
+    super.render(timestamp);
+    this.fourDimensionalState.topologyPulse = Math.max(0, this.fourDimensionalState.topologyPulse * 0.88);
+  }
 
-    /**
-     * Hide canvas layers for this system
-     */
-    hideCanvasLayers() {
-        const layers = document.getElementById('polychoraLayers');
-        if (layers) {
-            layers.style.display = 'none';
-            layers.style.visibility = 'hidden';
-            layers.style.opacity = '0';
-            console.log('🔮 PolychoraSystem: Canvas layers hidden');
-        }
-    }
-
-    /**
-     * Setup polytope UI exactly like index.html - 4D POLYTOPE NAMES
-     */
-    setupPolytopes() {
-        const geometryGrid = document.getElementById('geometryGrid');
-        if (!geometryGrid) return;
-        
-        geometryGrid.innerHTML = '';
-        
-        this.polytopes.forEach((polytope, index) => {
-            const btn = document.createElement('button');
-            btn.className = 'geom-btn';
-            btn.textContent = polytope;
-            btn.dataset.index = index;
-            btn.onclick = () => this.selectPolytope(index);
-            
-            // Set active state for default polytope (index 0)
-            if (index === 0) {
-                btn.classList.add('active');
-            }
-            
-            geometryGrid.appendChild(btn);
-        });
-        
-        console.log('🔮 PolychoraSystem: 4D polytope UI setup complete');
-    }
-
-    /**
-     * Initialize 4D parameters exactly like index.html
-     */
-    initializeParameters() {
-        // 4D POLYTOPE specific parameters - glassmorphic theme
-        const defaultParams = {
-            geometry: 0,        // Actually polytope index for polychora
-            rot4dXW: 0,         // CRITICAL: 4D rotations are key for polytopes
-            rot4dYW: 0, 
-            rot4dZW: 0,
-            gridDensity: 25,    // Higher density for complex polytopes
-            morphFactor: 1.0,
-            chaos: 0.1,         // Lower chaos for clean polytope math
-            speed: 0.8,         // Slower for contemplation
-            hue: 45,            // Orange/gold for polytopes
-            intensity: 0.4,     // Subtle intensity for glass effect
-            saturation: 0.7     // Moderate saturation
-        };
-        
-        Object.entries(defaultParams).forEach(([param, value]) => {
-            this.parameters.set(param, value);
-        });
-        
-        console.log('🔮 PolychoraSystem: 4D polytope parameters initialized');
-    }
-
-    /**
-     * Setup parameter listeners exactly like index.html
-     */
-    setupParameterListeners() {
-        // CRITICAL: Polychora system needs to hook into global parameter updates
-        const originalUpdateParameter = window.updateParameter;
-        
-        window.updateParameter = (param, value) => {
-            // If polychora system is active, handle the parameter
-            if (window.systemManager && window.systemManager.getCurrentSystemName() === 'polychora') {
-                this.updateParameter(param, value);
-            } else if (originalUpdateParameter) {
-                // Pass through to other systems
-                originalUpdateParameter(param, value);
-            }
-        };
-        
-        // CRITICAL: Polychora system needs to hook into global polytope selection
-        const originalSelectGeometry = window.selectGeometry;
-        
-        window.selectGeometry = (index) => {
-            // If polychora system is active, handle as polytope selection
-            if (window.systemManager && window.systemManager.getCurrentSystemName() === 'polychora') {
-                this.selectPolytope(index);
-            } else if (originalSelectGeometry) {
-                // Pass through to other systems
-                originalSelectGeometry(index);
-            }
-        };
-    }
-
-    /**
-     * Update parameter exactly like index.html - PRESERVE ALL 4D MATHEMATICS
-     */
-    updateParameter(param, value) {
-        console.log(`🔮 PolychoraSystem: Updating ${param} = ${value} with 4D polytope mathematics`);
-        
-        // Store parameter
-        this.parameters.set(param, value);
-        
-        // Update UI display
-        this.updateParameterDisplay(param, value);
-        
-        // Update engine if active - CRITICAL for 4D effects
-        if (this.engine && this.isActive) {
-            try {
-                // Polychora engine parameter update
-                if (this.engine.updateParameter) {
-                    this.engine.updateParameter(param, value);
-                } else if (this.engine.setParameter) {
-                    this.engine.setParameter(param, value);
-                } else {
-                    // Direct update for specific 4D parameters
-                    this.updatePolychoraParameter(param, value);
-                }
-                
-                // CRITICAL: Force immediate render for gallery preview mode
-                if (window.isGalleryPreview && this.engine.render) {
-                    this.engine.render();
-                }
-            } catch (error) {
-                console.warn(`🔮 PolychoraSystem: Parameter update failed for ${param}:`, error);
-            }
-        }
-    }
-
-    /**
-     * Update polychora-specific parameters
-     */
-    updatePolychoraParameter(param, value) {
-        // Handle 4D-specific parameter updates
-        if (param.startsWith('rot4d') && this.engine.setRotation) {
-            const rotations = {
-                rot4dXW: this.parameters.get('rot4dXW') || 0,
-                rot4dYW: this.parameters.get('rot4dYW') || 0,
-                rot4dZW: this.parameters.get('rot4dZW') || 0
-            };
-            rotations[param] = value;
-            this.engine.setRotation(rotations.rot4dXW, rotations.rot4dYW, rotations.rot4dZW);
-        } else if (param === 'geometry' && this.engine.setPolytope) {
-            this.engine.setPolytope(value);
-        }
-    }
-
-    /**
-     * Update parameter display exactly like index.html
-     */
-    updateParameterDisplay(param, value) {
-        // Update slider value
-        const slider = document.getElementById(param);
-        if (slider) {
-            slider.value = value;
-        }
-        
-        // Update value display
-        const displays = {
-            rot4dXW: 'xwValue',
-            rot4dYW: 'ywValue', 
-            rot4dZW: 'zwValue',
-            gridDensity: 'densityValue',
-            morphFactor: 'morphValue',
-            chaos: 'chaosValue',
-            speed: 'speedValue',
-            hue: 'hueValue',
-            intensity: 'intensityValue',
-            saturation: 'saturationValue'
-        };
-        
-        const displayId = displays[param];
-        if (displayId) {
-            const display = document.getElementById(displayId);
-            if (display) {
-                if (param === 'hue') {
-                    display.textContent = `${value}°`;
-                } else if (param === 'gridDensity') {
-                    display.textContent = value;
-                } else {
-                    display.textContent = parseFloat(value).toFixed(2);
-                }
-            }
-        }
-    }
-
-    /**
-     * Select polytope exactly like index.html - 4D SPECIFIC
-     */
-    selectPolytope(index) {
-        console.log(`🔮 PolychoraSystem: Selecting 4D polytope ${index} (${this.polytopes[index]})`);
-        
-        // Update UI
-        document.querySelectorAll('.geom-btn').forEach(btn => {
-            btn.classList.toggle('active', btn.dataset.index == index);
-        });
-        
-        // Update polytope in engine if active
-        if (this.engine && this.isActive) {
-            if (this.engine.setPolytope) {
-                this.engine.setPolytope(index);
-            } else if (this.engine.currentPolytope !== undefined) {
-                this.engine.currentPolytope = index;
-            }
-        }
-        
-        // Update parameter
-        this.updateParameter('geometry', index);
-    }
-
-    /**
-     * Update UI for this system - SHOW 4D FEATURES
-     */
-    updateUI() {
-        // Show geometry section for polychora system (shows polytopes)
-        const geometrySection = document.getElementById('geometrySection');
-        if (geometrySection) {
-            geometrySection.style.display = 'block';
-        }
-        
-        // Hide holographic section
-        const holographicSection = document.getElementById('holographicSection');
-        if (holographicSection) {
-            holographicSection.style.display = 'none';
-        }
-    }
-
-    /**
-     * Force render for gallery preview mode - CRITICAL for 4D effects
-     */
-    forceRender() {
-        if (this.engine && this.engine.render) {
-            // Call render multiple times to ensure 4D animation starts
-            for (let i = 0; i < 5; i++) {
-                setTimeout(() => this.engine.render(), i * 10);
-            }
-            console.log('🔮 PolychoraSystem: Force render triggered for gallery preview with glassmorphic 4D effects');
-        }
-    }
-
-    /**
-     * Get current parameters
-     */
-    getParameters() {
-        return new Map(this.parameters);
-    }
-
-    /**
-     * Get system info
-     */
-    getInfo() {
-        return {
-            name: this.name,
-            isActive: this.isActive,
-            isInitialized: this.isInitialized,
-            hasEngine: !!this.engine,
-            visualizerCount: this.visualizers.length,
-            polytopes: this.polytopes.length,
-            fourDimensional: true,  // Polychora system marker
-            effects: ['4d_polytopes', 'glassmorphic_rendering', 'true_4d_mathematics', '4d_rotations', 'distance_functions']
-        };
-    }
+  computeLayerUniforms(pipeline, palette) {
+    const uniforms = super.computeLayerUniforms(pipeline, palette);
+    const dimension = this.parameters.dimension ?? 3.8;
+    const rotationFactor = this.fourDimensionalState.rotationDrift;
+    uniforms.detail = Math.min(1, uniforms.detail + (dimension - 3) * 0.15);
+    uniforms.morph = Math.min(1, uniforms.morph + rotationFactor * 0.3 + this.fourDimensionalState.topologyPulse * 0.25);
+    uniforms.chaos = Math.min(2, uniforms.chaos + rotationFactor * 0.4);
+    uniforms.mix = Math.min(1, uniforms.mix + this.fourDimensionalState.topologyPulse * 0.2);
+    return uniforms;
+  }
 }
+
+export default PolychoraSystem;

--- a/src/core/ReactivityManager.js
+++ b/src/core/ReactivityManager.js
@@ -3,13 +3,25 @@
  * Handles 3 categories of reactivity that can work on any system
  */
 
+const PERF = typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance
+    : { now: () => Date.now() };
+
 export class ReactivityManager {
-    constructor() {
+    constructor(options = {}) {
         console.log('⚡ Initializing Modular Reactivity Manager');
-        
+
+        const {
+            onParameterUpdate = null,
+            onInteractionStateChange = null,
+        } = typeof options === 'object' && options !== null ? options : {};
+
+        this.onParameterUpdate = typeof onParameterUpdate === 'function' ? onParameterUpdate : null;
+        this.onInteractionStateChange = typeof onInteractionStateChange === 'function' ? onInteractionStateChange : null;
+
         // Global reactivity state
         this.enabled = true; // Master toggle (controlled by existing global toggle)
-        
+
         // Individual category toggles
         this.mouseEnabled = true;
         this.clickEnabled = true;
@@ -26,15 +38,79 @@ export class ReactivityManager {
         
         // Current selected modes (default to system-appropriate)
         this.currentMouseMode = 'rotations';   // Start with Faceted default
-        this.currentClickMode = 'ripple';      // Start with Faceted default (SWAPPED: now uses ripple for geometry changes)  
+        this.currentClickMode = 'ripple';      // Start with Faceted default (SWAPPED: now uses ripple for geometry changes)
         this.currentScrollMode = 'cycle';      // Start with Faceted default
-        
+
         // Initialize modes after constructor completes
         setTimeout(() => this.initializeModes(), 0);
-        
+
+        this.interactionState = this.createDefaultInteractionState();
+        this.lastMouseSample = {
+            x: 0.5,
+            y: 0.5,
+            timestamp: PERF.now(),
+        };
+
         this.setupGlobalListeners();
+        // Emit an initial snapshot so downstream systems have baseline interaction data
+        setTimeout(() => this.emitInteractionState(), 0);
     }
-    
+
+    /**
+     * Create a fresh interaction snapshot used for parameter mapping
+     */
+    createDefaultInteractionState() {
+        const now = PERF.now();
+        return {
+            mouseMovement: {
+                normalizedX: 0.5,
+                normalizedY: 0.5,
+                velocity: 0,
+                lastTimestamp: now,
+            },
+            scroll: {
+                lastDelta: 0,
+                lastTimestamp: 0,
+            },
+            clickHold: {
+                lastIntensity: 0,
+                lastTimestamp: 0,
+            },
+            pattern: {
+                type: 'none',
+            },
+            meta: {
+                lastInteractionTimestamp: now,
+            },
+        };
+    }
+
+    /**
+     * Emit the current interaction snapshot to listeners
+     */
+    emitInteractionState() {
+        if (!this.onInteractionStateChange) {
+            return;
+        }
+
+        try {
+            const snapshot = JSON.parse(JSON.stringify(this.interactionState));
+            this.onInteractionStateChange(snapshot);
+        } catch (error) {
+            console.warn('⚡ ReactivityManager failed to emit interaction state', error);
+        }
+    }
+
+    /**
+     * Record an interaction timestamp for idle tracking
+     */
+    recordInteraction(timestamp = PERF.now()) {
+        if (!this.interactionState.meta) {
+            this.interactionState.meta = {};
+        }
+        this.interactionState.meta.lastInteractionTimestamp = timestamp;
+    }
+
     /**
      * Initialize mode instances after class definitions are loaded
      */
@@ -130,15 +206,33 @@ export class ReactivityManager {
      */
     handleGlobalMouseMove(e) {
         if (!this.enabled || !this.mouseEnabled || !this.isCanvasEvent(e)) return;
-        
+
         const coords = this.getEventCoords(e);
         if (!coords) return;
-        
+
+        const now = PERF.now();
+        const lastSample = this.lastMouseSample || { x: coords.x, y: coords.y, timestamp: now };
+        const deltaTime = Math.max(16, now - lastSample.timestamp);
+        const deltaX = coords.x - lastSample.x;
+        const deltaY = coords.y - lastSample.y;
+        const velocity = Math.min(1, Math.sqrt(deltaX * deltaX + deltaY * deltaY) / Math.max(0.0001, deltaTime / 16));
+
+        this.interactionState.mouseMovement = {
+            normalizedX: coords.x,
+            normalizedY: coords.y,
+            velocity,
+            lastTimestamp: now,
+        };
+        this.lastMouseSample = { x: coords.x, y: coords.y, timestamp: now };
+        this.recordInteraction(now);
+
         // Route to current mouse mode (check if modes are initialized)
         const mode = this.mouseModes && this.mouseModes[this.currentMouseMode];
         if (mode && mode.handleMouseMove) {
             mode.handleMouseMove(coords.x, coords.y, this.updateParameter.bind(this));
         }
+
+        this.emitInteractionState();
     }
     
     /**
@@ -146,15 +240,25 @@ export class ReactivityManager {
      */
     handleGlobalClick(e) {
         if (!this.enabled || !this.clickEnabled || !this.isCanvasEvent(e)) return;
-        
+
         const coords = this.getEventCoords(e);
         if (!coords) return;
-        
+
+        const now = PERF.now();
+        const clickState = this.interactionState.clickHold || (this.interactionState.clickHold = {});
+        clickState.lastIntensity = Math.min(1, (clickState.lastIntensity ?? 0) + 1);
+        clickState.lastTimestamp = now;
+        this.interactionState.pattern = this.interactionState.pattern || {};
+        this.interactionState.pattern.type = 'click';
+        this.recordInteraction(now);
+
         // Route to current click mode (check if modes are initialized)
         const mode = this.clickModes && this.clickModes[this.currentClickMode];
         if (mode && mode.handleClick) {
             mode.handleClick(coords.x, coords.y, this.updateParameter.bind(this));
         }
+
+        this.emitInteractionState();
     }
     
     /**
@@ -162,14 +266,23 @@ export class ReactivityManager {
      */
     handleGlobalWheel(e) {
         if (!this.enabled || !this.scrollEnabled || !this.isCanvasEvent(e)) return;
-        
+
         e.preventDefault();
-        
+
+        const now = PERF.now();
+        const scrollState = this.interactionState.scroll || (this.interactionState.scroll = {});
+        const normalizedDelta = Math.min(1, Math.abs(e.deltaY) / 480);
+        scrollState.lastDelta = normalizedDelta;
+        scrollState.lastTimestamp = now;
+        this.recordInteraction(now);
+
         // Route to current scroll mode (check if modes are initialized)
         const mode = this.scrollModes && this.scrollModes[this.currentScrollMode];
         if (mode && mode.handleWheel) {
             mode.handleWheel(e.deltaY, this.updateParameter.bind(this));
         }
+
+        this.emitInteractionState();
     }
     
     /**
@@ -199,21 +312,39 @@ export class ReactivityManager {
      */
     handleGlobalTouchMove(e) {
         if (!this.enabled || !this.mouseEnabled || !this.isCanvasEvent(e)) return;
-        
+
         e.preventDefault();
         if (e.touches.length > 0) {
             const touch = e.touches[0];
             const rect = e.target.getBoundingClientRect();
             const x = (touch.clientX - rect.left) / rect.width;
             const y = (touch.clientY - rect.top) / rect.height;
-            
+
+            const now = PERF.now();
+            const lastSample = this.lastMouseSample || { x, y, timestamp: now };
+            const deltaTime = Math.max(16, now - lastSample.timestamp);
+            const deltaX = x - lastSample.x;
+            const deltaY = y - lastSample.y;
+            const velocity = Math.min(1, Math.sqrt(deltaX * deltaX + deltaY * deltaY) / Math.max(0.0001, deltaTime / 16));
+
+            this.interactionState.mouseMovement = {
+                normalizedX: x,
+                normalizedY: y,
+                velocity,
+                lastTimestamp: now,
+            };
+            this.lastMouseSample = { x, y, timestamp: now };
+            this.recordInteraction(now);
+
             const mode = this.mouseModes && this.mouseModes[this.currentMouseMode];
             if (mode && mode.handleMouseMove) {
                 mode.handleMouseMove(x, y, this.updateParameter.bind(this));
             }
+
+            this.emitInteractionState();
         }
     }
-    
+
     handleGlobalTouchEnd(e) {
         if (!this.enabled || !this.clickEnabled || !this.isCanvasEvent(e)) return;
         
@@ -222,11 +353,21 @@ export class ReactivityManager {
             const rect = e.target.getBoundingClientRect();
             const x = (touch.clientX - rect.left) / rect.width;
             const y = (touch.clientY - rect.top) / rect.height;
-            
+
+            const now = PERF.now();
+            const clickState = this.interactionState.clickHold || (this.interactionState.clickHold = {});
+            clickState.lastIntensity = Math.min(1, (clickState.lastIntensity ?? 0) + 1);
+            clickState.lastTimestamp = now;
+            this.interactionState.pattern = this.interactionState.pattern || {};
+            this.interactionState.pattern.type = 'tap';
+            this.recordInteraction(now);
+
             const mode = this.clickModes && this.clickModes[this.currentClickMode];
             if (mode && mode.handleClick) {
                 mode.handleClick(x, y, this.updateParameter.bind(this));
             }
+
+            this.emitInteractionState();
         }
     }
     
@@ -234,14 +375,34 @@ export class ReactivityManager {
      * Update parameter on active system (conflict resolution: active system wins)
      */
     updateParameter(param, value) {
-        // Active system takes control - simple conflict resolution
-        if (window.updateParameter) {
-            window.updateParameter(param, value);
+        if (!param) {
+            return;
         }
-        
-        console.log(`⚡ ${this.activeSystemName} reactivity: ${param} = ${value}`);
+
+        this.recordInteraction(PERF.now());
+
+        let resolvedValue = value;
+        if (typeof resolvedValue === 'string') {
+            const numeric = Number(resolvedValue);
+            if (!Number.isNaN(numeric)) {
+                resolvedValue = numeric;
+            }
+        }
+
+        if (this.onParameterUpdate) {
+            try {
+                this.onParameterUpdate(param, resolvedValue);
+            } catch (error) {
+                console.warn('⚡ ReactivityManager parameter callback failed', error);
+            }
+        } else if (typeof window !== 'undefined' && window.updateParameter) {
+            window.updateParameter(param, resolvedValue);
+        }
+
+        console.log(`⚡ ${this.activeSystemName} reactivity: ${param} = ${resolvedValue}`);
+        this.emitInteractionState();
     }
-    
+
     /**
      * Toggle methods for UI
      */
@@ -269,6 +430,15 @@ export class ReactivityManager {
             console.log(`⚡ Mouse mode: ${mode}`);
         } else {
             console.error(`❌ Mouse mode '${mode}' not found. Available modes:`, Object.keys(this.mouseModes || {}));
+        }
+    }
+
+    getInteractionState() {
+        try {
+            return JSON.parse(JSON.stringify(this.interactionState));
+        } catch (error) {
+            console.warn('⚡ ReactivityManager failed to clone interaction state', error);
+            return this.interactionState;
         }
     }
     

--- a/src/core/ResourceManager.js
+++ b/src/core/ResourceManager.js
@@ -1,0 +1,603 @@
+/**
+ * ResourceManager
+ * ------------------------------------------------------------
+ * Production-ready WebGL resource lifecycle manager that tracks GPU
+ * allocations, monitors memory pressure and ensures contexts are
+ * cleaned up deterministically. The implementation follows the
+ * Resource Management System defined in PROPER_ARCHITECTURE_SOLUTIONS.md.
+ */
+
+const SUPPORTED_RESOURCE_TYPES = ['buffer', 'texture', 'program', 'shader'];
+
+const DEFAULT_MEMORY_LIMIT = 256 * 1024 * 1024; // 256MB
+
+const PERF = typeof performance !== 'undefined'
+  ? performance
+  : { now: () => Date.now() };
+
+function getWindow() {
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  return undefined;
+}
+
+export class ResourceManager {
+  constructor() {
+    this.contexts = new Map();
+    this.resources = new Map();
+    this.resourceTypes = new Map();
+    this.resourceUsers = new Map();
+    this.sharedResources = new Map();
+
+    this.memoryUsage = {
+      buffers: 0,
+      textures: 0,
+      shaders: 0,
+      total: 0,
+    };
+
+    this.maxMemoryUsage = DEFAULT_MEMORY_LIMIT;
+    this.cleanupThreshold = 0.8;
+    this.nextResourceId = 1;
+
+    this.memoryMonitor = null;
+    this.healthMonitor = null;
+    this.startMonitoring();
+  }
+
+  startMonitoring() {
+    const globalWindow = getWindow();
+    const setIntervalFn = globalWindow?.setInterval ?? setInterval;
+
+    this.memoryMonitor = setIntervalFn(() => {
+      this.checkMemoryPressure();
+    }, 5000);
+
+    this.healthMonitor = setIntervalFn(() => {
+      this.checkContextHealth();
+    }, 10000);
+  }
+
+  stopMonitoring() {
+    const globalWindow = getWindow();
+    const clearIntervalFn = globalWindow?.clearInterval ?? clearInterval;
+
+    if (this.memoryMonitor) {
+      clearIntervalFn(this.memoryMonitor);
+      this.memoryMonitor = null;
+    }
+
+    if (this.healthMonitor) {
+      clearIntervalFn(this.healthMonitor);
+      this.healthMonitor = null;
+    }
+  }
+
+  registerWebGLContext(contextId, gl, { label } = {}) {
+    if (!contextId || !gl) {
+      throw new Error('ResourceManager: registerWebGLContext requires an id and context');
+    }
+
+    const existing = this.contexts.get(contextId);
+    if (existing && existing.gl === gl) {
+      return existing;
+    }
+
+    const record = {
+      id: contextId,
+      label: label || contextId,
+      gl,
+      resources: new Set(),
+      lastCheck: PERF.now(),
+      lost: false,
+    };
+
+    this.contexts.set(contextId, record);
+
+    if (typeof gl.canvas?.addEventListener === 'function') {
+      gl.canvas.addEventListener('webglcontextlost', () => this.handleContextLost(contextId));
+      gl.canvas.addEventListener('webglcontextrestored', () => this.handleContextRestored(contextId));
+    }
+
+    return record;
+  }
+
+  unregisterWebGLContext(contextId) {
+    const record = this.contexts.get(contextId);
+    if (!record) {
+      return;
+    }
+
+    this.releaseContextResources(contextId);
+    this.contexts.delete(contextId);
+  }
+
+  handleContextLost(contextId) {
+    const record = this.contexts.get(contextId);
+    if (!record) {
+      return;
+    }
+
+    record.lost = true;
+    this.releaseContextResources(contextId);
+  }
+
+  handleContextRestored(contextId) {
+    const record = this.contexts.get(contextId);
+    if (!record) {
+      return;
+    }
+
+    record.lost = false;
+    record.lastCheck = PERF.now();
+  }
+
+  generateResourceId(type) {
+    const current = this.nextResourceId;
+    this.nextResourceId += 1;
+    return `${type}-${current}`;
+  }
+
+  trackResource(contextId, type, handle, dispose, metadata = {}) {
+    if (!SUPPORTED_RESOURCE_TYPES.includes(type)) {
+      throw new Error(`ResourceManager: unsupported resource type ${type}`);
+    }
+
+    const context = this.contexts.get(contextId);
+    if (!context) {
+      throw new Error(`ResourceManager: context ${contextId} not registered`);
+    }
+
+    const resourceId = this.generateResourceId(type);
+    this.resources.set(resourceId, {
+      id: resourceId,
+      type,
+      contextId,
+      handle,
+      dispose,
+      metadata,
+    });
+
+    this.resourceTypes.set(resourceId, type);
+    this.resourceUsers.set(resourceId, new Set());
+    context.resources.add(resourceId);
+
+    if (type === 'buffer') {
+      this.memoryUsage.buffers += metadata.size ?? 0;
+      this.memoryUsage.total += metadata.size ?? 0;
+    } else if (type === 'texture') {
+      this.memoryUsage.textures += metadata.size ?? 0;
+      this.memoryUsage.total += metadata.size ?? 0;
+    } else if (type === 'shader' || type === 'program') {
+      this.memoryUsage.shaders += metadata.size ?? 0;
+      this.memoryUsage.total += metadata.size ?? 0;
+    }
+
+    return resourceId;
+  }
+
+  releaseResource(resourceId) {
+    const resource = this.resources.get(resourceId);
+    if (!resource) {
+      return;
+    }
+
+    const { contextId, type, metadata } = resource;
+
+    try {
+      if (typeof resource.dispose === 'function') {
+        const context = this.contexts.get(contextId);
+        resource.dispose(context?.gl, resource.handle, metadata);
+      }
+    } finally {
+      this.resources.delete(resourceId);
+      this.resourceTypes.delete(resourceId);
+      this.resourceUsers.delete(resourceId);
+
+      const context = this.contexts.get(contextId);
+      context?.resources.delete(resourceId);
+
+      if (type === 'buffer') {
+        this.memoryUsage.buffers -= metadata.size ?? 0;
+        this.memoryUsage.total -= metadata.size ?? 0;
+      } else if (type === 'texture') {
+        this.memoryUsage.textures -= metadata.size ?? 0;
+        this.memoryUsage.total -= metadata.size ?? 0;
+      } else if (type === 'shader' || type === 'program') {
+        this.memoryUsage.shaders -= metadata.size ?? 0;
+        this.memoryUsage.total -= metadata.size ?? 0;
+      }
+    }
+  }
+
+  releaseContextResources(contextId) {
+    const context = this.contexts.get(contextId);
+    if (!context) {
+      return;
+    }
+
+    [...context.resources].forEach((resourceId) => this.releaseResource(resourceId));
+    context.resources.clear();
+  }
+
+  attachResourceToUser(resourceId, userId) {
+    const users = this.resourceUsers.get(resourceId);
+    if (!users) {
+      return;
+    }
+    users.add(userId);
+  }
+
+  detachResourceFromUser(resourceId, userId) {
+    const users = this.resourceUsers.get(resourceId);
+    if (!users) {
+      return;
+    }
+    users.delete(userId);
+  }
+
+  createBuffer(contextId, data, usage) {
+    const context = this.contexts.get(contextId);
+    if (!context) {
+      throw new Error(`ResourceManager: context ${contextId} not registered`);
+    }
+
+    const { gl } = context;
+    const buffer = gl.createBuffer();
+    if (!buffer) {
+      throw new Error('ResourceManager: failed to create buffer');
+    }
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, data, usage ?? gl.STATIC_DRAW);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+    const metadata = {
+      size: data?.byteLength ?? 0,
+      data: data ? new data.constructor(data) : null,
+    };
+    const resourceId = this.trackResource(contextId, 'buffer', buffer, (ctx, handle) => {
+      ctx?.deleteBuffer(handle);
+    }, metadata);
+
+    return {
+      id: resourceId,
+      handle: buffer,
+      buffer,
+      metadata,
+    };
+  }
+
+  createTexture(contextId, {
+    width = 1,
+    height = 1,
+    data = null,
+    format,
+    type,
+    minFilter,
+    magFilter,
+    wrapS,
+    wrapT,
+  } = {}) {
+    const context = this.contexts.get(contextId);
+    if (!context) {
+      throw new Error(`ResourceManager: context ${contextId} not registered`);
+    }
+
+    const { gl } = context;
+    const texture = gl.createTexture();
+    if (!texture) {
+      throw new Error('ResourceManager: failed to create texture');
+    }
+
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, minFilter ?? gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, magFilter ?? gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrapS ?? gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrapT ?? gl.CLAMP_TO_EDGE);
+
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      format ?? gl.RGBA,
+      width,
+      height,
+      0,
+      format ?? gl.RGBA,
+      type ?? gl.UNSIGNED_BYTE,
+      data,
+    );
+
+    gl.bindTexture(gl.TEXTURE_2D, null);
+
+    const metadata = {
+      size: width * height * 4,
+      width,
+      height,
+      data: data ? (data.slice ? data.slice() : new Uint8Array(data)) : null,
+    };
+    const resourceId = this.trackResource(contextId, 'texture', texture, (ctx, handle) => {
+      ctx?.deleteTexture(handle);
+    }, metadata);
+
+    return {
+      id: resourceId,
+      handle: texture,
+      texture,
+      metadata,
+    };
+  }
+
+  createGradientTexture(contextId, stops = 256) {
+    const data = new Uint8Array(stops * 4);
+    for (let i = 0; i < stops; i += 1) {
+      const t = i / (stops - 1);
+      const hue = t * 360;
+      const [r, g, b] = this.hslToRgb(hue, 100, 50);
+      data[i * 4 + 0] = r;
+      data[i * 4 + 1] = g;
+      data[i * 4 + 2] = b;
+      data[i * 4 + 3] = 255;
+    }
+
+    return this.createTexture(contextId, {
+      width: stops,
+      height: 1,
+      data,
+    });
+  }
+
+  createNoiseTexture(contextId, size = 32) {
+    const context = this.contexts.get(contextId);
+    if (!context) {
+      throw new Error(`ResourceManager: context ${contextId} not registered`);
+    }
+
+    const { gl } = context;
+    const supports3D = typeof gl.TEXTURE_3D !== 'undefined' && typeof gl.texImage3D === 'function';
+    const data = new Uint8Array(size * size * (supports3D ? size : 1));
+    for (let i = 0; i < data.length; i += 1) {
+      data[i] = Math.floor(Math.random() * 256);
+    }
+
+    const texture = gl.createTexture();
+    if (!texture) {
+      throw new Error('ResourceManager: failed to create noise texture');
+    }
+
+    const metadata = { size: data.length };
+
+    if (supports3D) {
+      gl.bindTexture(gl.TEXTURE_3D, texture);
+      gl.texImage3D(gl.TEXTURE_3D, 0, gl.R8, size, size, size, 0, gl.RED, gl.UNSIGNED_BYTE, data);
+      gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_WRAP_S, gl.REPEAT);
+      gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_WRAP_T, gl.REPEAT);
+      gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_WRAP_R, gl.REPEAT);
+      gl.bindTexture(gl.TEXTURE_3D, null);
+    } else {
+      gl.bindTexture(gl.TEXTURE_2D, texture);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.ALPHA, size, size, 0, gl.ALPHA, gl.UNSIGNED_BYTE, data);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
+      gl.bindTexture(gl.TEXTURE_2D, null);
+    }
+
+    const resourceId = this.trackResource(contextId, 'texture', texture, (ctx, handle) => {
+      ctx?.deleteTexture(handle);
+    }, metadata);
+
+    return {
+      id: resourceId,
+      handle: texture,
+      texture,
+      target: supports3D ? gl.TEXTURE_3D : gl.TEXTURE_2D,
+      metadata,
+    };
+  }
+
+  createProgram(contextId, vertexSource, fragmentSource) {
+    const context = this.contexts.get(contextId);
+    if (!context) {
+      throw new Error(`ResourceManager: context ${contextId} not registered`);
+    }
+
+    const { gl } = context;
+    const vertexShader = this.compileShader(gl, gl.VERTEX_SHADER, vertexSource);
+    const fragmentShader = this.compileShader(gl, gl.FRAGMENT_SHADER, fragmentSource);
+    const program = gl.createProgram();
+    if (!program) {
+      throw new Error('ResourceManager: failed to create program');
+    }
+
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      const log = gl.getProgramInfoLog(program);
+      gl.deleteProgram(program);
+      gl.deleteShader(vertexShader);
+      gl.deleteShader(fragmentShader);
+      throw new Error(`ResourceManager: program link failed: ${log}`);
+    }
+
+    const metadata = { size: 0 };
+    const resourceId = this.trackResource(contextId, 'program', program, (ctx, handle) => {
+      ctx?.deleteProgram(handle);
+    }, metadata);
+
+    gl.deleteShader(vertexShader);
+    gl.deleteShader(fragmentShader);
+
+    return {
+      id: resourceId,
+      handle: program,
+      program,
+      metadata,
+    };
+  }
+
+  createShaderSuite(contextId, shaderSources) {
+    const context = this.contexts.get(contextId);
+    if (!context) {
+      throw new Error(`ResourceManager: context ${contextId} not registered`);
+    }
+
+    const { gl } = context;
+    const collection = new Map();
+
+    Object.entries(shaderSources).forEach(([key, source]) => {
+      const shader = this.compileShader(gl, key.includes('vertex') ? gl.VERTEX_SHADER : gl.FRAGMENT_SHADER, source);
+      const metadata = { size: source.length };
+      const resourceId = this.trackResource(contextId, 'shader', shader, (ctx, handle) => {
+        ctx?.deleteShader(handle);
+      }, metadata);
+      collection.set(key, {
+        id: resourceId,
+        handle: shader,
+        shader,
+        metadata,
+      });
+    });
+
+    return collection;
+  }
+
+  compileShader(gl, shaderType, source) {
+    const shader = gl.createShader(shaderType);
+    if (!shader) {
+      throw new Error('ResourceManager: failed to create shader');
+    }
+
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+      const log = gl.getShaderInfoLog(shader);
+      gl.deleteShader(shader);
+      throw new Error(`ResourceManager: shader compile failed: ${log}`);
+    }
+
+    return shader;
+  }
+
+  releaseSharedResource(type, key, resource) {
+    const handle = resource?.handle
+      ?? resource?.buffer
+      ?? resource?.texture
+      ?? resource?.shader
+      ?? resource?.program
+      ?? resource;
+
+    if (type === 'buffers') {
+      this.releaseByHandle(handle);
+    } else if (type === 'textures') {
+      this.releaseByHandle(handle);
+    } else if (type === 'shaders') {
+      this.releaseByHandle(handle);
+    } else if (type === 'programs') {
+      this.releaseByHandle(handle);
+    }
+  }
+
+  releaseByHandle(handle) {
+    if (!handle) {
+      return;
+    }
+
+    for (const [resourceId, record] of this.resources.entries()) {
+      if (record.handle === handle) {
+        this.releaseResource(resourceId);
+        return;
+      }
+    }
+  }
+
+  checkMemoryPressure() {
+    if (this.memoryUsage.total < this.maxMemoryUsage * this.cleanupThreshold) {
+      return;
+    }
+
+    const excess = this.memoryUsage.total - this.maxMemoryUsage * this.cleanupThreshold;
+    if (excess <= 0) {
+      return;
+    }
+
+    const candidates = [...this.resources.values()]
+      .filter((resource) => (resource.metadata?.size ?? 0) > 0)
+      .sort((a, b) => (a.metadata?.lastUsed ?? 0) - (b.metadata?.lastUsed ?? 0));
+
+    let freed = 0;
+    for (const candidate of candidates) {
+      if (freed >= excess) {
+        break;
+      }
+      freed += candidate.metadata?.size ?? 0;
+      this.releaseResource(candidate.id);
+    }
+  }
+
+  checkContextHealth() {
+    this.contexts.forEach((record, contextId) => {
+      if (record.lost) {
+        return;
+      }
+
+      const gl = record.gl;
+      if (gl && typeof gl.isContextLost === 'function' && gl.isContextLost()) {
+        console.warn(`ResourceManager: detected lost context ${contextId}`);
+        this.handleContextLost(contextId);
+      }
+    });
+  }
+
+  hslToRgb(h, s, l) {
+    const sat = s / 100;
+    const light = l / 100;
+    const c = (1 - Math.abs(2 * light - 1)) * sat;
+    const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+    const m = light - c / 2;
+
+    let r = 0;
+    let g = 0;
+    let b = 0;
+
+    if (h < 60) {
+      r = c; g = x; b = 0;
+    } else if (h < 120) {
+      r = x; g = c; b = 0;
+    } else if (h < 180) {
+      r = 0; g = c; b = x;
+    } else if (h < 240) {
+      r = 0; g = x; b = c;
+    } else if (h < 300) {
+      r = x; g = 0; b = c;
+    } else {
+      r = c; g = 0; b = x;
+    }
+
+    return [
+      Math.round((r + m) * 255),
+      Math.round((g + m) * 255),
+      Math.round((b + m) * 255),
+    ];
+  }
+
+  dispose() {
+    [...this.resources.keys()].forEach((resourceId) => this.releaseResource(resourceId));
+    this.contexts.clear();
+    this.sharedResources.clear();
+    this.stopMonitoring();
+  }
+
+  destroy() {
+    this.dispose();
+  }
+}
+
+export default ResourceManager;

--- a/src/core/StateManager.js
+++ b/src/core/StateManager.js
@@ -1,0 +1,606 @@
+/**
+ * StateManager
+ * ------------------------------------------------------------
+ * Production-ready, Redux-inspired state container that powers the
+ * system orchestration documented in PROPER_ARCHITECTURE_SOLUTIONS.md.
+ * The manager provides reducers for the major domains, middleware for
+ * validation/persistence, a bounded history for time-travel debugging
+ * and selectors for high-level queries.
+ */
+
+const INIT_ACTION = { type: '@@state/INIT' };
+
+const PERF = typeof performance !== 'undefined'
+  ? performance
+  : { now: () => Date.now() };
+
+const hasLocalStorage = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+export class StateManager {
+  constructor(options = {}) {
+    this.state = this.getInitialState();
+    this.reducers = new Map();
+    this.middleware = [];
+    this.listeners = new Set();
+    this.stateHistory = [];
+    this.maxHistorySize = 50;
+    this.persistenceTimeout = null;
+    const performanceOptions = options.performanceOptions || options.performance || {};
+    const {
+      enablePerformanceLogging = true,
+      slowReducerThresholdMs = 5,
+      maxPerformanceSamples = 120,
+      onSlowReducer = null,
+      onPerformanceSample = null,
+      logger = null,
+    } = performanceOptions;
+
+    this.performanceOptions = {
+      enablePerformanceLogging: Boolean(enablePerformanceLogging),
+      slowReducerThresholdMs: typeof slowReducerThresholdMs === 'number'
+        ? Math.max(0, slowReducerThresholdMs)
+        : 5,
+      maxPerformanceSamples: typeof maxPerformanceSamples === 'number' && maxPerformanceSamples > 0
+        ? Math.ceil(maxPerformanceSamples)
+        : 120,
+      onSlowReducer: typeof onSlowReducer === 'function' ? onSlowReducer : null,
+      onPerformanceSample: typeof onPerformanceSample === 'function' ? onPerformanceSample : null,
+      logger: typeof logger === 'function' ? logger : null,
+    };
+
+    this.performanceSamples = [];
+
+    this.initializeReducers();
+    this.initializeMiddleware();
+  }
+
+  getInitialState() {
+    return {
+      game: {
+        state: 'menu',
+        score: 0,
+        level: 1,
+        sublevel: 1,
+        health: 100,
+        combo: 0,
+        lives: 3,
+      },
+      visualization: {
+        activeSystem: 'faceted',
+        parameters: {
+          chaos: 0.5,
+          complexity: 0.7,
+          hue: 240,
+          saturation: 0.8,
+          brightness: 0.6,
+          dimension: 3.5,
+          gridDensity: 10,
+          morphSpeed: 1,
+        },
+        performance: {
+          fps: 60,
+          frameTime: 16.67,
+          renderTime: 10,
+          memoryUsage: 0,
+        },
+      },
+      audio: {
+        isActive: false,
+        sourceType: null,
+        reactive: {
+          bass: 0,
+          mid: 0,
+          high: 0,
+          energy: 0,
+        },
+        analysis: {
+          tempo: 120,
+          beats: [],
+          frequencyData: null,
+        },
+      },
+      ui: {
+        showHUD: true,
+        showDebugInfo: false,
+        activePanel: null,
+        notifications: [],
+      },
+      system: {
+        isInitialized: false,
+        lastError: null,
+        webglSupport: false,
+        audioSupport: false,
+        performanceLevel: 'high',
+      },
+    };
+  }
+
+  initializeReducers() {
+    this.registerReducer('game', this.gameReducer.bind(this));
+    this.registerReducer('visualization', this.visualizationReducer.bind(this));
+    this.registerReducer('audio', this.audioReducer.bind(this));
+    this.registerReducer('ui', this.uiReducer.bind(this));
+    this.registerReducer('system', this.systemReducer.bind(this));
+  }
+
+  initializeMiddleware() {
+    this.middleware.push(this.validateStateMiddleware.bind(this));
+    this.middleware.push(this.persistenceMiddleware.bind(this));
+    this.middleware.push(this.performanceMiddleware.bind(this));
+
+    if (typeof process !== 'undefined' && process?.env?.NODE_ENV === 'development') {
+      this.middleware.push(this.debugLoggerMiddleware.bind(this));
+    }
+  }
+
+  registerReducer(domain, reducer, initialState) {
+    if (typeof reducer !== 'function') {
+      throw new Error('StateManager.registerReducer expects a reducer function');
+    }
+
+    this.reducers.set(domain, reducer);
+    if (initialState !== undefined) {
+      this.state[domain] = initialState;
+    } else if (!this.state[domain]) {
+      this.state[domain] = reducer(undefined, INIT_ACTION);
+    }
+
+    return () => {
+      this.reducers.delete(domain);
+      delete this.state[domain];
+    };
+  }
+
+  getState() {
+    return this.state;
+  }
+
+  dispatch(action) {
+    if (!action || typeof action.type !== 'string') {
+      throw new Error('StateManager.dispatch expects an action with a type');
+    }
+
+    let processedAction = action;
+    for (const middleware of this.middleware) {
+      const result = middleware(this.state, processedAction);
+      if (result === null) {
+        return action;
+      }
+      processedAction = result || processedAction;
+    }
+
+    const nextState = this.applyReducers(this.state, processedAction);
+    if (nextState === this.state) {
+      return processedAction;
+    }
+
+    const previousState = this.state;
+    this.state = nextState;
+    this.pushHistory(previousState, processedAction);
+    this.notifyListeners(nextState, previousState, processedAction);
+
+    return processedAction;
+  }
+
+  applyReducers(state, action) {
+    let hasChanged = false;
+    const nextState = { ...state };
+    const shouldMeasure = this.shouldMeasurePerformance();
+
+    this.reducers.forEach((reducer, domain) => {
+      const previousSlice = state[domain];
+      let nextSlice;
+
+      if (shouldMeasure) {
+        const start = PERF.now();
+        nextSlice = reducer(previousSlice, action);
+        const duration = PERF.now() - start;
+        this.handleReducerPerformance(domain, action.type, duration);
+      } else {
+        nextSlice = reducer(previousSlice, action);
+      }
+
+      if (nextSlice !== previousSlice) {
+        nextState[domain] = nextSlice;
+        hasChanged = true;
+      }
+    });
+
+    return hasChanged ? nextState : state;
+  }
+
+  pushHistory(previousState, action) {
+    this.stateHistory.push({ state: previousState, action, timestamp: Date.now() });
+    if (this.stateHistory.length > this.maxHistorySize) {
+      this.stateHistory.shift();
+    }
+  }
+
+  gameReducer(state = this.getInitialState().game, action) {
+    switch (action.type) {
+      case 'game/setState':
+        return { ...state, state: action.payload };
+      case 'game/updateScore':
+        return { ...state, score: Math.max(0, state.score + Number(action.payload || 0)) };
+      case 'game/setLevel':
+        return { ...state, level: action.payload.level, sublevel: action.payload.sublevel ?? 1 };
+      case 'game/updateHealth':
+        return { ...state, health: Math.max(0, Math.min(100, state.health + Number(action.payload || 0))) };
+      case 'game/updateCombo':
+        return { ...state, combo: Math.max(0, Number(action.payload || 0)) };
+      case 'game/resetCombo':
+        return { ...state, combo: 0 };
+      case 'game/loseLife':
+        return { ...state, lives: Math.max(0, state.lives - 1) };
+      case 'game/reset':
+        return { ...this.getInitialState().game, ...action.payload };
+      default:
+        return state;
+    }
+  }
+
+  visualizationReducer(state = this.getInitialState().visualization, action) {
+    switch (action.type) {
+      case 'visualization/switchSystem':
+        return { ...state, activeSystem: action.payload };
+      case 'visualization/updateParameters':
+        return { ...state, parameters: { ...state.parameters, ...action.payload } };
+      case 'visualization/setParameter':
+        return { ...state, parameters: { ...state.parameters, [action.payload.key]: action.payload.value } };
+      case 'visualization/updatePerformance':
+        return { ...state, performance: { ...state.performance, ...action.payload } };
+      case 'visualization/resetParameters':
+        return { ...state, parameters: this.getInitialState().visualization.parameters };
+      default:
+        return state;
+    }
+  }
+
+  audioReducer(state = this.getInitialState().audio, action) {
+    switch (action.type) {
+      case 'audio/setActive':
+        return { ...state, isActive: Boolean(action.payload) };
+      case 'audio/setSourceType':
+        return { ...state, sourceType: action.payload };
+      case 'audio/updateReactive':
+        return { ...state, reactive: { ...state.reactive, ...action.payload } };
+      case 'audio/updateAnalysis':
+        return { ...state, analysis: { ...state.analysis, ...action.payload } };
+      case 'audio/addBeat': {
+        const beats = [...state.analysis.beats, action.payload];
+        if (beats.length > 50) {
+          beats.shift();
+        }
+        return { ...state, analysis: { ...state.analysis, beats } };
+      }
+      default:
+        return state;
+    }
+  }
+
+  uiReducer(state = this.getInitialState().ui, action) {
+    switch (action.type) {
+      case 'ui/toggleHUD':
+        return { ...state, showHUD: !state.showHUD };
+      case 'ui/setActivePanel':
+        return { ...state, activePanel: action.payload };
+      case 'ui/addNotification':
+        return {
+          ...state,
+          notifications: [
+            ...state.notifications,
+            { id: Date.now(), timestamp: Date.now(), ...action.payload },
+          ],
+        };
+      case 'ui/removeNotification':
+        return { ...state, notifications: state.notifications.filter((note) => note.id !== action.payload) };
+      case 'ui/clearNotifications':
+        return { ...state, notifications: [] };
+      default:
+        return state;
+    }
+  }
+
+  systemReducer(state = this.getInitialState().system, action) {
+    switch (action.type) {
+      case 'system/initialize':
+        return { ...state, isInitialized: true };
+      case 'system/setError':
+        return { ...state, lastError: action.payload };
+      case 'system/clearError':
+        return { ...state, lastError: null };
+      case 'system/updateSupport':
+        return { ...state, ...action.payload };
+      case 'system/setPerformanceLevel':
+        return { ...state, performanceLevel: action.payload };
+      default:
+        return state;
+    }
+  }
+
+  validateStateMiddleware(prevState, action) {
+    if (!action?.type || typeof action.type !== 'string') {
+      console.error('StateManager: invalid action', action);
+      return null;
+    }
+
+    if (action.type === 'visualization/switchSystem') {
+      const valid = ['faceted', 'quantum', 'holographic', 'polychora', 'hypercube'];
+      if (!valid.includes(action.payload)) {
+        console.error('StateManager: invalid system', action.payload);
+        return null;
+      }
+    }
+
+    return action;
+  }
+
+  persistenceMiddleware(prevState, action) {
+    const persistentActions = [
+      'game/updateScore',
+      'game/setLevel',
+      'visualization/updateParameters',
+      'visualization/switchSystem',
+      'system/setPerformanceLevel',
+    ];
+
+    if (persistentActions.includes(action.type)) {
+      this.schedulePersistence();
+    }
+
+    return action;
+  }
+
+  performanceMiddleware(prevState, action) {
+    return action;
+  }
+
+  debugLoggerMiddleware(prevState, action) {
+    console.group?.(`%c[State] ${action.type}`, 'color:#4CAF50;font-weight:bold');
+    console.log?.('%cAction:', 'color:#2196F3', action);
+    console.log?.('%cPrevious State:', 'color:#FF9800', prevState);
+    setTimeout(() => {
+      console.log?.('%cNext State:', 'color:#4CAF50', this.state);
+      console.groupEnd?.();
+    }, 0);
+    return action;
+  }
+
+  subscribe(listener) {
+    if (typeof listener !== 'function') {
+      throw new Error('StateManager.subscribe expects a listener function');
+    }
+
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  notifyListeners(nextState, prevState, action) {
+    this.listeners.forEach((listener) => {
+      try {
+        listener(nextState, prevState, action);
+      } catch (error) {
+        console.error('StateManager listener error', error);
+      }
+    });
+  }
+
+  getGameState() {
+    return this.state.game;
+  }
+
+  getVisualizationState() {
+    return this.state.visualization;
+  }
+
+  getAudioState() {
+    return this.state.audio;
+  }
+
+  getUIState() {
+    return this.state.ui;
+  }
+
+  getSystemState() {
+    return this.state.system;
+  }
+
+  getIsGameActive() {
+    return this.state.game.state === 'playing';
+  }
+
+  getCanSwitchSystem() {
+    return this.state.game.state !== 'playing' || this.state.system.performanceLevel === 'ultra';
+  }
+
+  getAudioReactiveIntensity() {
+    const { bass, mid, high } = this.state.audio.reactive;
+    return (bass + mid + high) / 3;
+  }
+
+  getPerformanceScore() {
+    const perf = this.state.visualization.performance;
+    return Math.max(0, 100 - Math.max(0, perf.frameTime - 16.67) * 2);
+  }
+
+  shouldMeasurePerformance() {
+    const options = this.performanceOptions;
+    if (!options) {
+      return false;
+    }
+
+    return (
+      options.enablePerformanceLogging ||
+      typeof options.onPerformanceSample === 'function' ||
+      typeof options.onSlowReducer === 'function'
+    );
+  }
+
+  handleReducerPerformance(domain, actionType, duration) {
+    const options = this.performanceOptions;
+    if (!options) {
+      return;
+    }
+
+    const sample = {
+      domain,
+      actionType,
+      duration,
+      timestamp: Date.now(),
+    };
+
+    if (duration >= options.slowReducerThresholdMs) {
+      if (options.enablePerformanceLogging) {
+        const message = `StateManager: slow reducer for ${domain} (${actionType}) (${duration.toFixed(2)}ms)`;
+        if (options.logger) {
+          options.logger(message, sample);
+        } else {
+          console.warn?.(message);
+        }
+      }
+
+      if (options.onSlowReducer) {
+        options.onSlowReducer(sample);
+      }
+    }
+
+    this.recordPerformanceSample(sample);
+  }
+
+  recordPerformanceSample(sample) {
+    const options = this.performanceOptions;
+    if (!options) {
+      return;
+    }
+
+    this.performanceSamples.push(sample);
+    const overflow = this.performanceSamples.length - options.maxPerformanceSamples;
+    if (overflow > 0) {
+      this.performanceSamples.splice(0, overflow);
+    }
+
+    if (options.onPerformanceSample) {
+      options.onPerformanceSample(sample);
+    }
+  }
+
+  getPerformanceSamples() {
+    return [...this.performanceSamples];
+  }
+
+  clearPerformanceSamples() {
+    this.performanceSamples.length = 0;
+  }
+
+  schedulePersistence() {
+    if (!hasLocalStorage) {
+      return;
+    }
+
+    if (this.persistenceTimeout) {
+      clearTimeout(this.persistenceTimeout);
+    }
+
+    this.persistenceTimeout = setTimeout(() => this.persistState(), 1000);
+  }
+
+  persistState() {
+    if (!hasLocalStorage) {
+      return;
+    }
+
+    try {
+      const persistentState = {
+        game: {
+          score: this.state.game.score,
+          level: this.state.game.level,
+          sublevel: this.state.game.sublevel,
+        },
+        visualization: {
+          activeSystem: this.state.visualization.activeSystem,
+          parameters: this.state.visualization.parameters,
+        },
+        system: {
+          performanceLevel: this.state.system.performanceLevel,
+        },
+      };
+
+      window.localStorage.setItem('vib34d_game_state', JSON.stringify(persistentState));
+    } catch (error) {
+      console.error('StateManager: failed to persist state', error);
+    }
+  }
+
+  restoreState() {
+    if (!hasLocalStorage) {
+      return false;
+    }
+
+    try {
+      const stored = window.localStorage.getItem('vib34d_game_state');
+      if (!stored) {
+        return false;
+      }
+
+      const parsed = JSON.parse(stored);
+
+      if (parsed.game?.score) {
+        this.dispatch({ type: 'game/updateScore', payload: parsed.game.score });
+      }
+
+      if (parsed.game?.level) {
+        this.dispatch({ type: 'game/setLevel', payload: { level: parsed.game.level, sublevel: parsed.game.sublevel } });
+      }
+
+      if (parsed.visualization?.activeSystem) {
+        this.dispatch({ type: 'visualization/switchSystem', payload: parsed.visualization.activeSystem });
+      }
+
+      if (parsed.visualization?.parameters) {
+        this.dispatch({ type: 'visualization/updateParameters', payload: parsed.visualization.parameters });
+      }
+
+      if (parsed.system?.performanceLevel) {
+        this.dispatch({ type: 'system/setPerformanceLevel', payload: parsed.system.performanceLevel });
+      }
+
+      return true;
+    } catch (error) {
+      console.error('StateManager: failed to restore state', error);
+      return false;
+    }
+  }
+
+  timeTravel(stepIndex) {
+    if (stepIndex < 0 || stepIndex >= this.stateHistory.length) {
+      console.error('StateManager: invalid time travel index', stepIndex);
+      return false;
+    }
+
+    const step = this.stateHistory[stepIndex];
+    this.state = step.state;
+    this.notifyListeners(this.state, this.state, { type: 'system/timeTravel', payload: stepIndex });
+    return true;
+  }
+
+  exportState() {
+    return {
+      currentState: JSON.parse(JSON.stringify(this.state)),
+      history: this.stateHistory.map((entry) => ({ action: entry.action, timestamp: entry.timestamp })),
+    };
+  }
+
+  destroy() {
+    this.listeners.clear();
+    this.reducers.clear();
+    this.stateHistory = [];
+    if (this.persistenceTimeout) {
+      clearTimeout(this.persistenceTimeout);
+      this.persistenceTimeout = null;
+    }
+  }
+}
+
+export default StateManager;

--- a/src/core/VisualizerEngine.js
+++ b/src/core/VisualizerEngine.js
@@ -1,864 +1,611 @@
 /**
- * VIB34D Visualizer Engine
- * Integrates all 4D visualization systems for the rhythm game
+ * VisualizerEngine
+ * ------------------------------------------------------------
+ * High level facade that wires together the professional canvas pool,
+ * resource manager, engine coordinator and centralised state manager.
+ * The implementation adheres to the architectural guidance captured in
+ * COMPREHENSIVE_ARCHITECTURE_ANALYSIS.md and
+ * PROPER_ARCHITECTURE_SOLUTIONS.md: coordinated engine lifecycle,
+ * pooled canvases, shared GPU resources and state-driven transitions.
  */
 
 import { VIB34DIntegratedEngine as FacetedEngine } from './Engine.js';
-import { QuantumHolographicVisualizer as QuantumEngine } from '../quantum/QuantumVisualizer.js';
-import { HolographicVisualizer as HolographicEngine } from '../holograms/HolographicVisualizer.js';
+import { QuantumEngine } from '../quantum/QuantumEngine.js';
+import { RealHolographicSystem } from '../holograms/RealHolographicSystem.js';
 import { PolychoraSystem } from './PolychoraSystem.js';
 import { HypercubeGameSystem } from '../visualizers/HypercubeGameSystem.js';
-import { CanvasManager } from './CanvasManager.js';
+import { CanvasResourcePool } from './CanvasManager.js';
+import { EngineCoordinator } from './EngineCoordinator.js';
 import { ReactivityManager } from './ReactivityManager.js';
+import { ResourceManager } from './ResourceManager.js';
+import { StateManager } from './StateManager.js';
+import { ParameterMappingSystem } from './ParameterMappingSystem.js';
+import { BaselineCaptureManager } from './BaselineCaptureManager.js';
+
+const COORDINATED_SYSTEMS = ['faceted', 'quantum', 'holographic', 'polychora'];
+
+const PERF = typeof performance !== 'undefined' ? performance : { now: () => Date.now() };
+
+const AUDIO_BAND_RANGES = [
+  { key: 'bass', start: 0.0, end: 0.1 },
+  { key: 'mid', start: 0.1, end: 0.5 },
+  { key: 'high', start: 0.5, end: 1.0 },
+];
+
+function amplitudeFromDecibels(value) {
+  if (!Number.isFinite(value) || value === -Infinity) {
+    return 0;
+  }
+  return Math.pow(10, value / 20);
+}
+
+function computeBandLevel(frequencyData, startRatio, endRatio) {
+  if (!frequencyData?.length) {
+    return 0;
+  }
+
+  const length = frequencyData.length;
+  const start = Math.max(0, Math.min(length - 1, Math.floor(length * startRatio)));
+  const end = Math.max(start + 1, Math.min(length, Math.floor(length * endRatio)));
+
+  let sum = 0;
+  let count = 0;
+  for (let i = start; i < end; i += 1) {
+    sum += amplitudeFromDecibels(frequencyData[i]);
+    count += 1;
+  }
+
+  if (count === 0) {
+    return 0;
+  }
+
+  const average = sum / count;
+  return Math.min(1, Math.sqrt(average) * 2);
+}
+
+function computeOverallEnergy(frequencyData) {
+  if (!frequencyData?.length) {
+    return 0;
+  }
+
+  let sum = 0;
+  for (let i = 0; i < frequencyData.length; i += 1) {
+    sum += amplitudeFromDecibels(frequencyData[i]);
+  }
+
+  const average = sum / frequencyData.length;
+  return Math.min(1, Math.sqrt(average) * 2);
+}
+
+function computeRms(timeDomainData) {
+  if (!timeDomainData?.length) {
+    return 0;
+  }
+
+  let sumSquares = 0;
+  for (let i = 0; i < timeDomainData.length; i += 1) {
+    const value = timeDomainData[i];
+    sumSquares += value * value;
+  }
+
+  return Math.sqrt(sumSquares / timeDomainData.length);
+}
 
 export class VisualizerEngine {
-    constructor(canvas) {
-        this.canvas = canvas;
-        this.gl = null;
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.gl = null;
 
-        // Available visualization systems
-        this.systems = {
-            faceted: null,
-            quantum: null,
-            holographic: null,
-            polychora: null,
-            hypercube: null  // BOMBASTIC HYPERCUBE SYSTEM!
-        };
+    this.resourceManager = new ResourceManager();
+    this.stateManager = new StateManager();
+    this.canvasPool = new CanvasResourcePool({ resourceManager: this.resourceManager });
+    this.engineCoordinator = new EngineCoordinator(this.canvasPool, {
+      resourceManager: this.resourceManager,
+      stateManager: this.stateManager,
+    });
 
-        this.currentSystem = 'faceted';
-        this.currentParameters = {};
+    this.reactivityManager = null;
+    this.hypercubeSystem = null;
+    this.currentSystem = 'faceted';
+    const visualizationState = this.stateManager.getVisualizationState();
+    this.currentParameters = { ...(visualizationState?.parameters || {}) };
+    this.parameterMappingSystem = new ParameterMappingSystem(this.currentParameters);
+    this.currentEffectiveParameters = this.parameterMappingSystem.getEffectiveParameters();
+    this.baselineManager = new BaselineCaptureManager({
+      engineCoordinator: this.engineCoordinator,
+      canvasPool: this.canvasPool,
+      parameterMappingSystem: this.parameterMappingSystem,
+    });
+    this.unsubscribe = null;
+    this.stateSyncInProgress = false;
+    this.initialised = false;
+  }
 
-        this.canvasManager = new CanvasManager();
-        this.reactivityManager = null;
-
-        // System switching state
-        this.isInitialized = false;
-        this.systemReady = false;
+  async initialize() {
+    this.gl = this.canvas.getContext('webgl2') || this.canvas.getContext('webgl');
+    if (!this.gl) {
+      throw new Error('VisualizerEngine: WebGL not supported');
     }
 
-    async initialize() {
-        try {
-            // Initialize WebGL context
-            this.gl = this.canvas.getContext('webgl2') || this.canvas.getContext('webgl');
-            if (!this.gl) {
-                throw new Error('WebGL not supported');
-            }
+    this.stateManager.dispatch({ type: 'system/updateSupport', payload: { webglSupport: true } });
 
-            // Initialize canvas manager
-            this.canvasManager.initialize(this.canvas);
-
-            // Initialize reactivity manager
-            this.reactivityManager = new ReactivityManager();
-            this.reactivityManager.initialize(this.canvas);
-
-            // Initialize with faceted system by default
-            await this.switchToSystem('faceted');
-
-            this.isInitialized = true;
-            console.log('VisualizerEngine initialized successfully');
-
-        } catch (error) {
-            console.error('Failed to initialize VisualizerEngine:', error);
-            throw error;
-        }
+    const restored = this.stateManager.restoreState();
+    const state = this.stateManager.getState();
+    this.currentParameters = { ...state.visualization.parameters };
+    if (this.parameterMappingSystem) {
+      this.parameterMappingSystem.setBaseParameters(this.currentParameters);
+      this.currentEffectiveParameters = this.parameterMappingSystem.getEffectiveParameters();
+    }
+    let initialSystem = restored ? state.visualization.activeSystem : 'faceted';
+    if (!COORDINATED_SYSTEMS.includes(initialSystem)) {
+      initialSystem = 'faceted';
     }
 
-    async switchToSystem(systemName) {
-        if (!['faceted', 'quantum', 'holographic', 'polychora', 'hypercube'].includes(systemName)) {
-            console.warn('Unknown system:', systemName);
-            return false;
+    this.canvasPool.initialize({ initialSystem });
+
+    this.registerEngines();
+    await this.engineCoordinator.initialize({ initialSystem });
+
+    await this.engineCoordinator.switchEngine(initialSystem);
+    this.currentSystem = initialSystem;
+    this.pushEffectiveParameters(initialSystem);
+
+    this.stateManager.dispatch({ type: 'system/initialize' });
+
+    this.reactivityManager = new ReactivityManager({
+      onParameterUpdate: (param, value) => this.handleInteractiveParameterUpdate(param, value),
+      onInteractionStateChange: (interactionState) => {
+        if (this.parameterMappingSystem?.setInteractionState(interactionState)) {
+          this.pushEffectiveParameters();
         }
-
-        try {
-            // Clean up current system
-            if (this.systems[this.currentSystem]) {
-                this.cleanupCurrentSystem();
-            }
-
-            // Initialize new system
-            this.currentSystem = systemName;
-            await this.initializeSystem(systemName);
-
-            // Apply current parameters to new system
-            if (Object.keys(this.currentParameters).length > 0) {
-                this.setParameters(this.currentParameters);
-            }
-
-            this.systemReady = true;
-            console.log(`Switched to ${systemName} system`);
-            return true;
-
-        } catch (error) {
-            console.error(`Failed to switch to ${systemName} system:`, error);
-            return false;
-        }
-    }
-
-    async initializeSystem(systemName) {
-        const canvas = this.canvas;
-        const gl = this.gl;
-
-        try {
-            switch (systemName) {
-                case 'faceted':
-                    this.systems.faceted = new FacetedEngine();
-                    if (typeof this.systems.faceted.initialize === 'function') {
-                        await this.systems.faceted.initialize(canvas);
-                    }
-                    break;
-
-                case 'quantum':
-                    // Pass canvas ID to quantum visualizer
-                    this.systems.quantum = new QuantumEngine(canvas.id || 'game-canvas', 'content', 1.0, 0);
-                    if (typeof this.systems.quantum.initialize === 'function') {
-                        await this.systems.quantum.initialize(canvas);
-                    }
-                    break;
-
-                case 'holographic':
-                    // Pass canvas ID to holographic visualizer
-                    this.systems.holographic = new HolographicEngine(canvas.id || 'game-canvas', 'content', 1.0, 0);
-                    if (typeof this.systems.holographic.initialize === 'function') {
-                        await this.systems.holographic.initialize(canvas);
-                    }
-                    break;
-
-                case 'polychora':
-                    this.systems.polychora = new PolychoraSystem();
-                    if (typeof this.systems.polychora.initialize === 'function') {
-                        await this.systems.polychora.initialize(canvas);
-                    }
-                    break;
-
-                case 'hypercube':
-                    this.systems.hypercube = new HypercubeGameSystem(canvas);
-                    this.systems.hypercube.startExplosion(); // ACTIVATE BOMBASTIC MODE!
-                    console.log('🔥💥 HYPERCUBE GAME SYSTEM ACTIVATED - PREPARE FOR EXPLOSIVE VISUALS! 💥🔥');
-                    break;
-            }
-        } catch (error) {
-            console.warn(`Failed to initialize ${systemName} system, using fallback:`, error);
-            // Create a minimal fallback system
-            this.systems[systemName] = {
-                render: () => {
-                    // Simple fallback rendering
-                    if (this.gl) {
-                        this.gl.clearColor(0.0, 0.0, 0.2, 1.0);
-                        this.gl.clear(this.gl.COLOR_BUFFER_BIT);
-                    }
-                },
-                setParameters: () => {},
-                cleanup: () => {}
-            };
-        }
-    }
-
-    cleanupCurrentSystem() {
-        const system = this.systems[this.currentSystem];
-        if (system && typeof system.cleanup === 'function') {
-            system.cleanup();
-        }
-
-        // Clear canvas
-        if (this.gl) {
-            this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
-        }
-    }
-
-    setParameters(parameters) {
-        this.currentParameters = { ...parameters };
-
-        if (!this.systemReady) return;
-
-        const system = this.systems[this.currentSystem];
-        if (system) {
-            // Map generic parameters to system-specific methods
-            this.applyParametersToSystem(system, parameters);
-        }
-    }
-
-    applyParametersToSystem(system, params) {
-        // Apply geometry selection
-        if (params.geometry !== undefined && typeof system.setGeometry === 'function') {
-            system.setGeometry(params.geometry);
-        }
-
-        // Apply 4D rotation parameters
-        if (typeof system.set4DRotation === 'function') {
-            system.set4DRotation(
-                params.rot4dXW || 0,
-                params.rot4dYW || 0,
-                params.rot4dZW || 0
-            );
-        }
-
-        // Apply visual parameters
-        if (typeof system.setVisualParameters === 'function') {
-            system.setVisualParameters({
-                gridDensity: params.gridDensity || 15,
-                morphFactor: params.morphFactor || 1,
-                chaos: params.chaos || 0.2,
-                speed: params.speed || 1,
-                hue: params.hue || 200,
-                intensity: params.intensity || 0.5,
-                saturation: params.saturation || 0.8
-            });
-        }
-
-        // Apply dimension parameter
-        if (params.dimension !== undefined && typeof system.setDimension === 'function') {
-            system.setDimension(params.dimension);
-        }
-
-        // Fallback: try to update parameters via a generic method
-        if (typeof system.updateParameters === 'function') {
-            system.updateParameters(params);
-        }
-    }
-
-    render(timestamp = 0, gameState = {}) {
-        if (!this.systemReady || !this.gl) return;
-
-        const system = this.systems[this.currentSystem];
-        if (system && typeof system.render === 'function') {
-            system.render(timestamp, gameState);
-        }
-
-        // 🎮🔍 UPDATE HYPERCUBE GAME STATE VISUALS FOR TACTICAL INFO 🔍🎮
-        if (this.systems.hypercube && this.systems.hypercube.updateGameStateVisuals) {
-            this.systems.hypercube.updateGameStateVisuals(gameState);
-        }
-
-        // 🔥⚡ AMPLIFY CROSS-SYSTEM CONTRASTS FOR MAXIMUM EXCITEMENT ⚡🔥
-        this.amplifySystemContrasts(gameState);
-    }
-
-    // 💫🔍 TACTICAL INFORMATION OVERLAY FOR CROSS-SYSTEM COMMUNICATION 🔍💫
-
-    setTacticalInfo(infoType, intensity = 1.0) {
-        // Route tactical information to appropriate visualizer systems
-        if (this.systems.hypercube && this.systems.hypercube.setTacticalInfoMode) {
-            this.systems.hypercube.setTacticalInfoMode(infoType, intensity);
-        }
-
-        // Add tactical info display to other systems if they support it
-        console.log(`💫🔍 TACTICAL INFO BROADCAST: ${infoType} (intensity: ${intensity.toFixed(2)}) 🔍💫`);
-    }
-
-    // Switch to hypertetrahedron mode for maximum precision feedback
-    activateHypertetrahedronMode() {
-        if (this.systems.hypercube) {
-            this.systems.hypercube.explosiveState.hyperGeometryMode = 'hypertetrahedron';
-            this.systems.hypercube.explosiveState.dimensionalIntensity = Math.max(
-                this.systems.hypercube.explosiveState.dimensionalIntensity, 4.5
-            );
-            console.log('💫🔍 HYPERTETRAHEDRON MODE ACTIVATED FOR MAXIMUM PRECISION! 🔍💫');
-        }
-    }
-
-    // Enhanced glitch storm for enemy/chaos communication
-    triggerTacticalGlitchStorm(intensity = 1.0) {
-        if (this.systems.hypercube) {
-            this.systems.hypercube.explosiveState.glitchIntensity = Math.max(
-                this.systems.hypercube.explosiveState.glitchIntensity,
-                intensity * 0.8
-            );
-            this.systems.hypercube.explosiveState.moireDistortion = Math.max(
-                this.systems.hypercube.explosiveState.moireDistortion,
-                intensity * 0.6
-            );
-            console.log(`🌪️🔍 TACTICAL GLITCH STORM! Intensity: ${intensity.toFixed(2)} 🔍🌪️`);
-        }
-    }
-
-    // 🔥⚡ CROSS-SYSTEM CONTRAST & HIGHLIGHT AMPLIFICATION SYSTEM ⚡🔥
-
-    amplifySystemContrasts(gameState) {
-        // 💥🌟 CREATE EXPLOSIVE CONTRASTS BETWEEN VISUALIZER SYSTEMS 🌟💥
-
-        // Determine dominant emotion/state for contrast targeting
-        let dominantEmotion = 'harmony';
-        let contrastIntensity = 1.0;
-
-        if (gameState.health < 30) {
-            dominantEmotion = 'critical';
-            contrastIntensity = 2.0;
-        } else if (gameState.bossMode) {
-            dominantEmotion = 'boss';
-            contrastIntensity = 1.8;
-        } else if (gameState.comboMultiplier > 10) {
-            dominantEmotion = 'ecstasy';
-            contrastIntensity = 1.5;
-        } else if (gameState.chaosLevel > 70) {
-            dominantEmotion = 'chaos';
-            contrastIntensity = 1.3;
-        }
-
-        // Apply contrasts to active systems
-        this.applyHypercubeContrasts(dominantEmotion, contrastIntensity);
-        this.applyFacetedContrasts(dominantEmotion, contrastIntensity);
-        this.applyQuantumContrasts(dominantEmotion, contrastIntensity);
-        this.applyHolographicContrasts(dominantEmotion, contrastIntensity);
-
-        console.log(`🔥⚡ SYSTEM CONTRASTS AMPLIFIED! Emotion: ${dominantEmotion}, Intensity: ${contrastIntensity.toFixed(2)} ⚡🔥`);
-    }
-
-    applyHypercubeContrasts(emotion, intensity) {
-        if (!this.systems.hypercube) return;
-
-        const hc = this.systems.hypercube.explosiveState;
-
-        switch (emotion) {
-            case 'critical':
-                // MAXIMUM HYPERTETRAHEDRON PRECISION IN CRISIS
-                hc.hyperGeometryMode = 'hypertetrahedron';
-                hc.glitchIntensity = Math.max(hc.glitchIntensity, intensity * 0.9);
-                hc.colorShiftChaos = Math.max(hc.colorShiftChaos, intensity * 0.7);
-                hc.dimensionalIntensity = Math.max(hc.dimensionalIntensity, 4.8);
-                break;
-
-            case 'boss':
-                // ULTIMATE GEOMETRIC WARFARE MODE
-                hc.hyperGeometryMode = 'hypertetrahedron';
-                hc.gridViolence = Math.max(hc.gridViolence, 15.0 + intensity * 10.0);
-                hc.universeModifier = Math.max(hc.universeModifier, intensity * 2.0);
-                hc.moireDistortion = Math.max(hc.moireDistortion, intensity * 0.8);
-                break;
-
-            case 'ecstasy':
-                // EUPHORIC GEOMETRIC TRANSCENDENCE
-                hc.patternIntensity = Math.max(hc.patternIntensity, 1.5 + intensity * 0.8);
-                hc.dimensionalIntensity = Math.max(hc.dimensionalIntensity, 4.5 + intensity * 0.3);
-                hc.morphExplosion = Math.max(hc.morphExplosion, intensity * 0.6);
-                break;
-
-            case 'chaos':
-                // CHAOTIC GEOMETRIC STORM
-                hc.rotationChaos = Math.max(hc.rotationChaos, intensity * 1.2);
-                hc.colorShiftChaos = Math.max(hc.colorShiftChaos, intensity * 0.8);
-                hc.glitchIntensity = Math.max(hc.glitchIntensity, intensity * 0.6);
-                break;
-
-            default:
-                // HARMONIC BALANCE
-                hc.patternIntensity = Math.max(hc.patternIntensity, 1.0 + intensity * 0.3);
-                break;
-        }
-    }
-
-    applyFacetedContrasts(emotion, intensity) {
-        // Apply contrasting effects to faceted system if available
-        if (!this.systems.faceted) return;
-
-        // Faceted system provides GEOMETRIC STRUCTURE contrast to fluid systems
-        if (this.systems.faceted.setParameters) {
-            const contrastParams = {
-                morphFactor: emotion === 'chaos' ? 0.8 * intensity : 0.2,
-                gridDensity: emotion === 'boss' ? 15 + intensity * 5 : 8,
-                speed: emotion === 'ecstasy' ? 1.5 * intensity : 0.8,
-                chaos: emotion === 'critical' ? intensity * 0.9 : 0.3
-            };
-
-            // Apply parameters that CONTRAST with current hypercube state
-            this.systems.faceted.setParameters(contrastParams);
-            console.log('🔷⚡ FACETED GEOMETRIC CONTRAST APPLIED! ⚡🔷');
-        }
-    }
-
-    applyQuantumContrasts(emotion, intensity) {
-        // Apply contrasting quantum effects if quantum system available
-        if (!this.systems.quantum || !this.systems.quantum.setParameters) return;
-
-        // Quantum system provides PROBABILITY CLOUD contrast to precise geometry
-        const quantumParams = {
-            particleDensity: emotion === 'ecstasy' ? 2000 + intensity * 1000 : 1000,
-            waveIntensity: emotion === 'chaos' ? intensity * 1.5 : 0.8,
-            quantumTunneling: emotion === 'critical' ? intensity * 0.8 : 0.4,
-            uncertainty: emotion === 'boss' ? intensity * 1.2 : 0.6
-        };
-
-        this.systems.quantum.setParameters(quantumParams);
-        console.log('⚛️⚡ QUANTUM PROBABILITY CONTRAST APPLIED! ⚡⚛️');
-    }
-
-    applyHolographicContrasts(emotion, intensity) {
-        // Apply contrasting holographic effects if holographic system available
-        if (!this.systems.holographic || !this.systems.holographic.updateState) return;
-
-        // Holographic system provides DEPTH ILLUSION contrast to flat interfaces
-        const holoState = {
-            layerSeparation: emotion === 'boss' ? intensity * 50 : 20,
-            interferencePattern: emotion === 'chaos' ? intensity * 0.9 : 0.4,
-            depthIntensity: emotion === 'ecstasy' ? intensity * 1.3 : 0.8,
-            hologramStability: emotion === 'critical' ? 1.0 - intensity * 0.6 : 0.9
-        };
-
-        this.systems.holographic.updateState(holoState);
-        console.log('🌈⚡ HOLOGRAPHIC DEPTH CONTRAST APPLIED! ⚡🌈');
-    }
-
-    // 💫🎆 EXPLOSIVE CROSS-SYSTEM HIGHLIGHTING EFFECTS 🎆💫
-
-    highlightSystemInteractions(eventType, intensity = 1.0) {
-        // Create EXPLOSIVE highlighting effects across ALL systems simultaneously
-        switch (eventType) {
-            case 'mega_combo':
-                this.triggerMegaComboHighlight(intensity);
-                break;
-
-            case 'perfect_precision':
-                this.triggerPerfectPrecisionHighlight(intensity);
-                break;
-
-            case 'chaos_explosion':
-                this.triggerChaosExplosionHighlight(intensity);
-                break;
-
-            case 'boss_transcendence':
-                this.triggerBossTranscendenceHighlight(intensity);
-                break;
-
-            default:
-                this.triggerUniversalHighlight(intensity);
-                break;
-        }
-
-        console.log(`💫🎆 CROSS-SYSTEM HIGHLIGHT: ${eventType} (intensity: ${intensity.toFixed(2)}) 🎆💫`);
-    }
-
-    triggerMegaComboHighlight(intensity) {
-        // 🔥✨ ALL SYSTEMS EXPLODE WITH COMBO CELEBRATION ✨🔥
-        if (this.systems.hypercube) {
-            this.systems.hypercube.explosiveState.comboFireworks = intensity;
-            this.systems.hypercube.explosiveState.cosmicEuphoria = intensity;
-        }
-
-        // Contrast: While hypercube explodes, other systems provide structured celebration
-        if (this.systems.faceted) {
-            this.systems.faceted.setParameters({ speed: 2.0 * intensity, chaos: 0.1 });
-        }
-
-        console.log('🔥✨ MEGA COMBO: All systems synchronized in euphoric celebration! ✨🔥');
-    }
-
-    triggerPerfectPrecisionHighlight(intensity) {
-        // 💫🔍 HYPERTETRAHEDRON PRECISION WITH SYSTEM-WIDE CLARITY 🔍💫
-        if (this.systems.hypercube) {
-            this.systems.hypercube.explosiveState.hyperGeometryMode = 'hypertetrahedron';
-            this.systems.hypercube.explosiveState.patternIntensity = 2.0;
-            this.systems.hypercube.explosiveState.glitchIntensity *= 0.2; // Crystal clarity
-        }
-
-        // Contrast: Other systems become ultra-stable to highlight precision
-        if (this.systems.quantum) {
-            this.systems.quantum.setParameters({ uncertainty: 0.1, stability: 0.95 });
-        }
-
-        console.log('💫🔍 PERFECT PRECISION: Crystal clear hypertetrahedron with stable contrasts! 🔍💫');
-    }
-
-    triggerChaosExplosionHighlight(intensity) {
-        // 🌪️💥 MAXIMUM CHAOS ACROSS ALL SYSTEMS SIMULTANEOUSLY 💥🌪️
-        if (this.systems.hypercube) {
-            this.systems.hypercube.explosiveState.glitchIntensity = intensity;
-            this.systems.hypercube.explosiveState.colorShiftChaos = intensity;
-            this.systems.hypercube.explosiveState.rotationChaos = intensity * 1.5;
-        }
-
-        // Complement: Other systems add their own chaos flavors
-        if (this.systems.quantum) {
-            this.systems.quantum.setParameters({ chaos: intensity, waveIntensity: intensity * 1.2 });
-        }
-
-        console.log('🌪️💥 CHAOS EXPLOSION: All systems in synchronized chaos storm! 💥🌪️');
-    }
-
-    triggerBossTranscendenceHighlight(intensity) {
-        // 🐲🌌 ULTIMATE BOSS MODE ACROSS ALL REALITY 🌌🐲
-        if (this.systems.hypercube) {
-            this.systems.hypercube.explosiveState.bossRealityRift = intensity;
-            this.systems.hypercube.explosiveState.dimensionalIntensity = 4.8;
-            this.systems.hypercube.explosiveState.universeModifier = intensity * 2.5;
-        }
-
-        // All systems shift to maximum intensity boss mode
-        if (this.systems.faceted) {
-            this.systems.faceted.setParameters({ morphFactor: intensity * 0.8, gridDensity: 20 });
-        }
-
-        console.log('🐲🌌 BOSS TRANSCENDENCE: All reality systems at maximum dimensional warfare! 🌌🐲');
-    }
-
-    triggerUniversalHighlight(intensity) {
-        // 🌟💫 UNIVERSAL HARMONY HIGHLIGHT ACROSS ALL SYSTEMS 💫🌟
-        if (this.systems.hypercube) {
-            this.systems.hypercube.explosiveState.patternIntensity = 1.0 + intensity * 0.5;
-            this.systems.hypercube.explosiveState.cosmicEuphoria = intensity * 0.6;
-        }
-
-        console.log('🌟💫 UNIVERSAL HIGHLIGHT: Harmonic resonance across all systems! 💫🌟');
-    }
-
-    handleResize(width, height) {
-        this.canvas.width = width;
-        this.canvas.height = height;
-
-        if (this.gl) {
-            this.gl.viewport(0, 0, width, height);
-        }
-
-        // Notify current system of resize
-        const system = this.systems[this.currentSystem];
-        if (system && typeof system.handleResize === 'function') {
-            system.handleResize(width, height);
-        }
-
-        if (this.canvasManager) {
-            this.canvasManager.handleResize(width, height);
-        }
-    }
-
-    // Game-specific methods for challenge generation
-    getCurrentGeometryType() {
-        return this.currentParameters.geometry || 0;
-    }
-
-    getCurrentSystemName() {
-        return this.currentSystem;
-    }
-
-    getParameterValue(paramName) {
-        return this.currentParameters[paramName];
-    }
-
-    // Audio reactivity integration
-    onAudioData(audioData) {
-        const system = this.systems[this.currentSystem];
-        if (system && typeof system.onAudioData === 'function') {
-            system.onAudioData(audioData);
-        }
-    }
-
-    onBeat(beatData) {
-        const system = this.systems[this.currentSystem];
-        if (system && typeof system.onBeat === 'function') {
-            system.onBeat(beatData);
-        }
-    }
-
-    // Challenge generation helpers
-    generateChallengeFromCurrentState() {
-        const geometry = this.getCurrentGeometryType();
-        const systemName = this.getCurrentSystemName();
-        const params = this.currentParameters;
-
-        return {
-            geometryType: geometry,
-            visualizerSystem: systemName,
-            challengeParameters: {
-                gridDensity: params.gridDensity || 15,
-                dimension: params.dimension || 3.5,
-                chaos: params.chaos || 0.2,
-                morphFactor: params.morphFactor || 1
-            },
-            rotation4D: {
-                xw: params.rot4dXW || 0,
-                yw: params.rot4dYW || 0,
-                zw: params.rot4dZW || 0
-            }
-        };
-    }
-
-    // Utility methods for game integration
-    getSystemCapabilities() {
-        return {
-            faceted: {
-                geometries: 8, // 0-7
-                supports4D: true,
-                audioReactive: true
-            },
-            quantum: {
-                geometries: 8,
-                supports4D: true,
-                audioReactive: true,
-                specialFeature: 'velocity_tracking'
-            },
-            holographic: {
-                geometries: 1, // Single holographic mode
-                supports4D: true,
-                audioReactive: true,
-                specialFeature: 'shimmer_effects'
-            },
-            polychora: {
-                geometries: 6, // 4D polytopes
-                supports4D: true,
-                audioReactive: true,
-                specialFeature: 'true_4d_math'
-            },
-            hypercube: {
-                geometries: 3, // hypercube, hypersphere, hypertetrahedron
-                supports4D: true,
-                audioReactive: true,
-                specialFeature: 'BOMBASTIC_EXPLOSIONS'
-            }
-        };
-    }
-
-    // 🔥💥 BOMBASTIC GAME EVENT METHODS FOR MAXIMUM EXCITEMENT! 💥🔥
-
-    explodeBeat(intensity = 1.0) {
-        // Trigger beat explosion across ALL systems for MAXIMUM IMPACT
-        console.log(`🎵💥 SYSTEM-WIDE BEAT EXPLOSION! Intensity: ${intensity.toFixed(2)}`);
-
-        // Trigger beat in current system
-        const system = this.systems[this.currentSystem];
-        if (system) {
-            if (typeof system.explodeBeat === 'function') {
-                system.explodeBeat(intensity);
-            } else if (typeof system.triggerClick === 'function') {
-                // Fallback for other visualizers
-                system.triggerClick(0.5, 0.5);
-                if (system.clickIntensity !== undefined) {
-                    system.clickIntensity = intensity;
-                }
-            }
-        }
-
-        // Trigger explosions in hypercube system if available
-        if (this.systems.hypercube && this.systems.hypercube.explodeBeat) {
-            this.systems.hypercube.explodeBeat(intensity);
-        }
-    }
-
-    triggerComboFireworks(comboCount) {
-        console.log(`🔥✨ COMBO FIREWORKS ACROSS ALL SYSTEMS! ${comboCount}x MULTIPLIER!`);
-
-        // Trigger combo effects in current system
-        const system = this.systems[this.currentSystem];
-        if (system && typeof system.triggerMorphPulse === 'function') {
-            system.triggerMorphPulse(comboCount / 10.0);
-        }
-
-        // Special hypercube combo fireworks
-        if (this.systems.hypercube && this.systems.hypercube.triggerComboFireworks) {
-            this.systems.hypercube.triggerComboFireworks(comboCount);
-        }
-
-        // Cross-system contrast effects
-        this.createSystemContrast('combo', comboCount / 10.0);
-    }
-
-    damageShockwave(damageAmount) {
-        console.log(`💥⚡ DAMAGE SHOCKWAVE! ${damageAmount} damage - VISUAL CHAOS ACTIVATED!`);
-
-        // Create damage effects across systems
-        const system = this.systems[this.currentSystem];
-        if (system && typeof system.triggerChaos === 'function') {
-            system.triggerChaos(damageAmount / 20.0);
-        }
-
-        // Hypercube damage shockwave
-        if (this.systems.hypercube && this.systems.hypercube.damageShockwave) {
-            this.systems.hypercube.damageShockwave(damageAmount);
-        }
-
-        // Create red flash across all systems
-        this.createSystemContrast('damage', damageAmount / 100.0);
-    }
-
-    powerUpNova(powerLevel) {
-        console.log(`⭐💫 POWER-UP NOVA EXPLOSION! Level: ${powerLevel}`);
-
-        // Switch to hypercube system for maximum visual impact
-        if (this.currentSystem !== 'hypercube' && this.systems.hypercube) {
-            this.switchToSystem('hypercube');
-        }
-
-        // Trigger power-up effects
-        if (this.systems.hypercube && this.systems.hypercube.powerUpNova) {
-            this.systems.hypercube.powerUpNova(powerLevel);
-        }
-
-        this.createSystemContrast('powerup', powerLevel);
-    }
-
-    enemyGlitchStorm(intensity) {
-        console.log(`👹🌪️ ENEMY GLITCH STORM! Intensity: ${intensity.toFixed(2)}`);
-
-        // Apply glitch effects across systems
-        const system = this.systems[this.currentSystem];
-        if (system && typeof system.triggerGlitch === 'function') {
-            system.triggerGlitch(intensity);
-        }
-
-        // Hypercube glitch storm
-        if (this.systems.hypercube && this.systems.hypercube.enemyGlitchStorm) {
-            this.systems.hypercube.enemyGlitchStorm(intensity);
-        }
-
-        this.createSystemContrast('glitch', intensity);
-    }
-
-    enterBossRealityRift() {
-        console.log(`🐲🌌 BOSS REALITY RIFT! SWITCHING TO HYPERTETRAHEDRON MODE!`);
-
-        // Force switch to hypercube system with hypertetrahedron mode
-        this.switchToSystem('hypercube');
-
-        if (this.systems.hypercube && this.systems.hypercube.enterBossRealityRift) {
-            this.systems.hypercube.enterBossRealityRift();
-        }
-
-        // Apply reality rift effects across all systems
-        this.createSystemContrast('boss', 1.0);
-    }
-
-    levelTranscendence(newLevel) {
-        console.log(`🚀🌟 LEVEL TRANSCENDENCE! Level ${newLevel} - GEOMETRY EVOLUTION!`);
-
-        // Choose geometry system based on level for visual variety
-        const systemChoices = ['faceted', 'quantum', 'holographic', 'hypercube'];
-        const targetSystem = systemChoices[newLevel % systemChoices.length];
-
-        this.switchToSystem(targetSystem);
-
-        // Trigger transcendence effects
-        if (this.systems.hypercube && this.systems.hypercube.levelTranscendence) {
-            this.systems.hypercube.levelTranscendence(newLevel);
-        }
-
-        this.createSystemContrast('transcendence', 1.0);
-    }
-
-    // Create contrasting effects between systems for MAXIMUM VISUAL IMPACT
-    createSystemContrast(effectType, intensity) {
-        const contrastEffects = {
-            'combo': () => {
-                // Bright explosions with color shifts
-                this.applyGlobalColorShift(intensity * 60);
-                this.applyGlobalIntensityBoost(intensity * 0.5);
-            },
-            'damage': () => {
-                // Red flashes and chaos
-                this.applyGlobalColorShift(-30 * intensity); // Shift toward red
-                this.applyGlobalChaos(intensity * 0.8);
-            },
-            'powerup': () => {
-                // Golden glow and smooth morphing
-                this.applyGlobalColorShift(45 * intensity); // Golden yellow
-                this.applyGlobalMorphing(intensity * 0.6);
-            },
-            'glitch': () => {
-                // Chaos and distortion across all systems
-                this.applyGlobalChaos(intensity);
-                this.applyGlobalGlitch(intensity);
-            },
-            'boss': () => {
-                // Purple/magenta reality distortion
-                this.applyGlobalColorShift(300); // Magenta
-                this.applyGlobalIntensityBoost(1.0);
-                this.applyGlobalMorphing(1.0);
-            },
-            'transcendence': () => {
-                // Rainbow explosion
-                this.applyGlobalColorShift(intensity * 360);
-                this.applyGlobalIntensityBoost(1.0);
-            }
-        };
-
-        if (contrastEffects[effectType]) {
-            contrastEffects[effectType]();
-        }
-    }
-
-    // Global effect application methods
-    applyGlobalColorShift(hueShift) {
-        // Apply color shift to all compatible systems
-        Object.keys(this.systems).forEach(systemName => {
-            const system = this.systems[systemName];
-            if (system && typeof system.shiftHue === 'function') {
-                system.shiftHue(hueShift);
-            }
+      },
+    });
+    this.reactivityManager.initialize(this.canvas);
+    this.reactivityManager.setActiveSystem(initialSystem, this.engineCoordinator.getEngine(initialSystem));
+
+    this.unsubscribe = this.stateManager.subscribe((nextState, prevState) => {
+      if (this.stateSyncInProgress) {
+        return;
+      }
+
+      const desiredSystem = nextState.visualization.activeSystem;
+      if (desiredSystem && desiredSystem !== this.currentSystem) {
+        this.switchToSystem(desiredSystem, { fromState: true });
+      }
+
+      if (nextState.visualization.parameters !== prevState?.visualization?.parameters) {
+        this.applyParameters(nextState.visualization.parameters || {}, {
+          replace: true,
+          suppressDispatch: true,
         });
-    }
+      }
+    });
 
-    applyGlobalIntensityBoost(boost) {
-        Object.keys(this.systems).forEach(systemName => {
-            const system = this.systems[systemName];
-            if (system && typeof system.boostIntensity === 'function') {
-                system.boostIntensity(boost);
-            }
+    this.initialised = true;
+  }
+
+  registerEngines() {
+    this.engineCoordinator.registerEngine('faceted', FacetedEngine, {
+      requiredLayers: ['background', 'shadow', 'content', 'highlight', 'accent'],
+      initializationOrder: 1,
+    });
+    this.engineCoordinator.registerEngine('quantum', QuantumEngine, {
+      requiredLayers: ['background', 'shadow', 'content', 'highlight', 'accent'],
+      initializationOrder: 2,
+    });
+    this.engineCoordinator.registerEngine('holographic', RealHolographicSystem, {
+      requiredLayers: ['background', 'shadow', 'content', 'highlight', 'accent'],
+      initializationOrder: 3,
+    });
+    this.engineCoordinator.registerEngine('polychora', PolychoraSystem, {
+      requiredLayers: ['background', 'shadow', 'content', 'highlight', 'accent'],
+      initializationOrder: 4,
+    });
+  }
+
+  async switchToSystem(systemName, { fromState = false } = {}) {
+    if (systemName === 'hypercube') {
+      if (!this.hypercubeSystem) {
+        const hypercubeResources = this.canvasPool.getCanvasResources('hypercube', 'content');
+        if (!hypercubeResources) {
+          throw new Error('VisualizerEngine: no hypercube canvas available from pool');
+        }
+
+        this.hypercubeSystem = new HypercubeGameSystem({
+          canvasResources: hypercubeResources,
+          resourceManager: this.resourceManager,
+          systemName: 'hypercube',
         });
+        if (typeof this.hypercubeSystem.initialize === 'function') {
+          await this.hypercubeSystem.initialize();
+        } else if (typeof this.hypercubeSystem.initializeExplosiveSystem === 'function') {
+          this.hypercubeSystem.initializeExplosiveSystem();
+        }
+      }
+
+      await this.engineCoordinator.switchEngine('faceted');
+      this.canvasPool.switchToSystem('hypercube');
+      this.currentSystem = 'hypercube';
+      this.reactivityManager?.setActiveSystem('hypercube', this.hypercubeSystem);
+      const hypercubeResource = this.canvasPool.getCanvasResources('hypercube', 'content');
+      const rect = hypercubeResource?.canvas?.getBoundingClientRect?.();
+      if (rect) {
+        this.hypercubeSystem?.handleResize?.(rect.width, rect.height);
+      }
+      this.parameterMappingSystem?.setBaseParameters(this.currentParameters);
+      this.pushEffectiveParameters('hypercube');
+
+      if (!fromState) {
+        this.stateManager.dispatch({ type: 'visualization/switchSystem', payload: 'hypercube' });
+      }
+      return true;
     }
 
-    applyGlobalChaos(chaosLevel) {
-        Object.keys(this.systems).forEach(systemName => {
-            const system = this.systems[systemName];
-            if (system && typeof system.applyChaos === 'function') {
-                system.applyChaos(chaosLevel);
-            }
+    if (!COORDINATED_SYSTEMS.includes(systemName)) {
+      console.warn(`VisualizerEngine: unknown system ${systemName}`);
+      return false;
+    }
+
+    const switched = await this.engineCoordinator.switchEngine(systemName);
+    if (!switched) {
+      return false;
+    }
+
+    this.currentSystem = systemName;
+    const engine = this.engineCoordinator.getEngine(systemName);
+    this.reactivityManager?.setActiveSystem(systemName, engine);
+    this.parameterMappingSystem?.setBaseParameters(this.currentParameters);
+    this.pushEffectiveParameters(systemName);
+
+    if (!fromState) {
+      this.stateManager.dispatch({ type: 'visualization/switchSystem', payload: systemName });
+    }
+
+    return true;
+  }
+
+  applyParameters(parameters, { targetSystem = this.currentSystem, replace = false, suppressDispatch = false } = {}) {
+    const nextParameters = replace ? { ...parameters } : { ...this.currentParameters, ...parameters };
+    this.currentParameters = nextParameters;
+
+    let effectiveParameters = nextParameters;
+    if (this.parameterMappingSystem) {
+      this.parameterMappingSystem.setBaseParameters(this.currentParameters);
+      effectiveParameters = this.parameterMappingSystem.getEffectiveParameters();
+    } else {
+      effectiveParameters = { ...nextParameters };
+    }
+
+    this.currentEffectiveParameters = { ...effectiveParameters };
+    this.applyEffectiveParameters(targetSystem, effectiveParameters);
+
+    if (!suppressDispatch) {
+      this.stateSyncInProgress = true;
+      try {
+        this.stateManager.dispatch({
+          type: 'visualization/updateParameters',
+          payload: nextParameters,
         });
+      } finally {
+        this.stateSyncInProgress = false;
+      }
+    }
+  }
+
+  setParameters(parameters) {
+    this.applyParameters(parameters, { replace: true });
+  }
+
+  updateParameters(parameters) {
+    this.applyParameters(parameters);
+  }
+
+  applyParametersToSystem(system, params) {
+    if (!system || !params) {
+      return;
     }
 
-    applyGlobalMorphing(morphLevel) {
-        Object.keys(this.systems).forEach(systemName => {
-            const system = this.systems[systemName];
-            if (system && typeof system.applyMorphing === 'function') {
-                system.applyMorphing(morphLevel);
-            }
-        });
+    if (typeof system.setGeometry === 'function' && params.geometry !== undefined) {
+      system.setGeometry(params.geometry);
     }
 
-    applyGlobalGlitch(glitchLevel) {
-        Object.keys(this.systems).forEach(systemName => {
-            const system = this.systems[systemName];
-            if (system && typeof system.applyGlitch === 'function') {
-                system.applyGlitch(glitchLevel);
-            }
-        });
+    if (typeof system.set4DRotation === 'function') {
+      system.set4DRotation(params.rot4dXW || 0, params.rot4dYW || 0, params.rot4dZW || 0);
     }
 
-    // Audio explosive reactivity for ALL systems
-    updateAudioExplosion(audioData) {
-        // Send audio data to hypercube system for explosive processing
-        if (this.systems.hypercube && this.systems.hypercube.updateAudioExplosion) {
-            this.systems.hypercube.updateAudioExplosion(audioData);
-        }
-
-        // Apply to current system as well
-        if (this.systems[this.currentSystem] && typeof this.systems[this.currentSystem].onAudioData === 'function') {
-            this.systems[this.currentSystem].onAudioData(audioData);
-        }
-
-        // Trigger explosive events based on audio intensity
-        if (audioData.bass > 0.8) {
-            this.explodeBeat(audioData.bass);
-        }
-
-        if (audioData.high > 0.9 && Math.random() < 0.3) {
-            this.enemyGlitchStorm(audioData.high);
-        }
-
-        if (audioData.energy > 0.95) {
-            this.triggerComboFireworks(Math.floor(audioData.energy * 20));
-        }
+    if (typeof system.setVisualParameters === 'function') {
+      system.setVisualParameters({
+        gridDensity: params.gridDensity ?? 15,
+        morphFactor: params.morphFactor ?? 1,
+        chaos: params.chaos ?? 0.2,
+        speed: params.speed ?? 1,
+        hue: params.hue ?? 200,
+        intensity: params.intensity ?? 0.5,
+        saturation: params.saturation ?? 0.8,
+      });
     }
 
-    cleanup() {
-        // Cleanup all systems
-        Object.keys(this.systems).forEach(systemName => {
-            const system = this.systems[systemName];
-            if (system && typeof system.cleanup === 'function') {
-                system.cleanup();
-            }
-        });
-
-        if (this.reactivityManager) {
-            this.reactivityManager.cleanup();
-        }
-
-        if (this.canvasManager) {
-            this.canvasManager.cleanup();
-        }
+    if (typeof system.setDimension === 'function' && params.dimension !== undefined) {
+      system.setDimension(params.dimension);
     }
+
+    system.updateParameters?.(params);
+    system.setParameters?.(params);
+  }
+
+  applyEffectiveParameters(targetSystem = this.currentSystem, effectiveParameters = this.currentEffectiveParameters) {
+    if (!effectiveParameters) {
+      return;
+    }
+
+    if (targetSystem === 'hypercube' && this.hypercubeSystem) {
+      this.applyParametersToSystem(this.hypercubeSystem, effectiveParameters);
+      return;
+    }
+
+    this.engineCoordinator.applyParameters(effectiveParameters, targetSystem);
+  }
+
+  pushEffectiveParameters(targetSystem = this.currentSystem) {
+    const effective = this.parameterMappingSystem
+      ? this.parameterMappingSystem.getEffectiveParameters()
+      : { ...this.currentParameters };
+
+    this.currentEffectiveParameters = { ...effective };
+    this.applyEffectiveParameters(targetSystem, effective);
+  }
+
+  handleInteractiveParameterUpdate(param, value) {
+    if (!param) {
+      return;
+    }
+
+    let resolvedValue = value;
+    if (typeof resolvedValue === 'string') {
+      const numeric = Number(resolvedValue);
+      if (!Number.isNaN(numeric)) {
+        resolvedValue = numeric;
+      }
+    }
+
+    this.applyParameters({ [param]: resolvedValue });
+  }
+
+  getEngine(systemName = this.currentSystem) {
+    if (systemName === 'hypercube') {
+      return this.hypercubeSystem;
+    }
+    return this.engineCoordinator.getEngine(systemName);
+  }
+
+  async captureBaselines(requests = [], options = {}) {
+    if (!this.baselineManager) {
+      return [];
+    }
+    return this.baselineManager.captureBaselines(requests, options);
+  }
+
+  invokeAcrossSystems(methodName, args = [], { includeHypercube = true } = {}) {
+    if (!methodName) {
+      return false;
+    }
+
+    let handled = false;
+
+    if (typeof this.engineCoordinator.broadcast === 'function') {
+      handled = this.engineCoordinator.broadcast(methodName, ...args) || handled;
+    } else {
+      const engine = this.getEngine(this.currentSystem);
+      const fn = engine?.[methodName];
+      if (typeof fn === 'function') {
+        fn.apply(engine, args);
+        handled = true;
+      }
+    }
+
+    if (includeHypercube && this.hypercubeSystem) {
+      const fn = this.hypercubeSystem[methodName];
+      if (typeof fn === 'function') {
+        fn.apply(this.hypercubeSystem, args);
+        handled = true;
+      }
+    }
+
+    return handled;
+  }
+
+  pushNotification(message, level = 'info', context = 'visualizer') {
+    if (!message) {
+      return;
+    }
+
+    try {
+      this.stateManager.dispatch({
+        type: 'ui/addNotification',
+        payload: { message, level, context },
+      });
+    } catch (error) {
+      console.warn('VisualizerEngine: failed to push notification', error);
+    }
+  }
+
+  onAudioData(audioData) {
+    if (!audioData) {
+      return;
+    }
+
+    const { frequencyData, timeDomainData } = audioData;
+    const reactivePayload = {};
+
+    if (frequencyData?.length) {
+      AUDIO_BAND_RANGES.forEach(({ key, start, end }) => {
+        reactivePayload[key] = computeBandLevel(frequencyData, start, end);
+      });
+
+      reactivePayload.energy = computeOverallEnergy(frequencyData);
+    }
+
+    if (Object.keys(reactivePayload).length > 0) {
+      this.stateManager.dispatch({
+        type: 'audio/updateReactive',
+        payload: reactivePayload,
+      });
+      if (this.parameterMappingSystem?.setAudioState(reactivePayload)) {
+        this.pushEffectiveParameters();
+      }
+    }
+
+    const analysisPayload = {};
+    if (Number.isFinite(audioData.energy)) {
+      analysisPayload.energy = audioData.energy;
+    } else if (reactivePayload.energy !== undefined) {
+      analysisPayload.energy = reactivePayload.energy;
+    }
+
+    if (timeDomainData?.length) {
+      analysisPayload.rms = computeRms(timeDomainData);
+    }
+
+    if (Object.keys(analysisPayload).length > 0) {
+      analysisPayload.timestamp = PERF.now();
+      this.stateManager.dispatch({
+        type: 'audio/updateAnalysis',
+        payload: analysisPayload,
+      });
+    }
+
+    this.invokeAcrossSystems('onAudioData', [audioData]);
+    this.invokeAcrossSystems('updateAudio', [audioData]);
+  }
+
+  explodeBeat(intensity = 1.0, beatData = {}) {
+    const payload = {
+      intensity,
+      timestamp: PERF.now(),
+      ...beatData,
+    };
+
+    this.stateManager.dispatch({ type: 'audio/addBeat', payload });
+
+    const handled = this.invokeAcrossSystems('explodeBeat', [intensity]);
+    this.invokeAcrossSystems('onBeat', [payload]);
+
+    if (!handled) {
+      this.invokeAcrossSystems('highlightSystemInteractions', ['beat', Math.min(1, intensity)], { includeHypercube: false });
+    }
+  }
+
+  triggerComboFireworks(comboCount = 0) {
+    const intensity = Math.min(1, Math.max(0, comboCount) / 10);
+    const handled = this.invokeAcrossSystems('triggerComboFireworks', [comboCount, intensity]);
+
+    if (!handled) {
+      this.highlightSystemInteractions('mega_combo', Math.max(intensity, 0.3));
+    }
+  }
+
+  highlightSystemInteractions(eventType, intensity = 1.0) {
+    const handled = this.invokeAcrossSystems('highlightSystemInteractions', [eventType, intensity]);
+
+    if (!handled) {
+      this.pushNotification(`Highlight: ${eventType}`, 'info', 'visualizer');
+    }
+  }
+
+  enemyGlitchStorm(intensity = 1.0) {
+    const handled = this.invokeAcrossSystems('enemyGlitchStorm', [intensity]);
+    if (!handled) {
+      this.highlightSystemInteractions('chaos_explosion', intensity);
+    }
+  }
+
+  damageShockwave(amount = 0) {
+    const handled = this.invokeAcrossSystems('damageShockwave', [amount]);
+    if (!handled) {
+      this.highlightSystemInteractions('damage', Math.min(1, Math.abs(amount) / 50));
+    }
+    const magnitude = Math.round(Math.abs(amount));
+    if (magnitude > 0) {
+      this.pushNotification(`Damage taken: ${magnitude}`, 'warning', 'combat');
+    }
+  }
+
+  powerUpNova(powerLevel = 1.0) {
+    const handled = this.invokeAcrossSystems('powerUpNova', [powerLevel]);
+    if (!handled) {
+      this.highlightSystemInteractions('power_up', Math.min(1, powerLevel));
+    }
+    this.pushNotification('Power-up acquired!', 'success', 'gameplay');
+  }
+
+  levelTranscendence(level = 1) {
+    this.invokeAcrossSystems('levelTranscendence', [level]);
+    this.pushNotification(`Level ${level} reached`, 'success', 'progression');
+  }
+
+  enterBossRealityRift() {
+    const handled = this.invokeAcrossSystems('enterBossRealityRift', []);
+    if (!handled) {
+      this.highlightSystemInteractions('boss_transcendence', 1.0);
+    }
+    this.pushNotification('Boss encounter initiated', 'danger', 'boss');
+  }
+
+  setTacticalInfo(infoType, intensity = 1.0) {
+    this.invokeAcrossSystems('setTacticalInfo', [infoType, intensity]);
+    this.pushNotification(`Tactical info: ${infoType}`, 'info', 'tactics');
+  }
+
+  activateHypertetrahedronMode() {
+    const handled = this.invokeAcrossSystems('activateHypertetrahedronMode', []);
+    if (!handled && this.hypercubeSystem) {
+      this.hypercubeSystem.explosiveState = this.hypercubeSystem.explosiveState || {};
+      this.hypercubeSystem.explosiveState.hyperGeometryMode = 'hypertetrahedron';
+    }
+  }
+
+  triggerTacticalGlitchStorm(intensity = 1.0) {
+    const handled = this.invokeAcrossSystems('triggerTacticalGlitchStorm', [intensity]);
+    if (!handled) {
+      this.enemyGlitchStorm(intensity);
+    }
+  }
+
+  render(timestamp, frameData) {
+    if (!this.initialised) {
+      return;
+    }
+
+    if (this.currentSystem === 'hypercube' && this.hypercubeSystem) {
+      this.hypercubeSystem.render?.(timestamp, frameData);
+      return;
+    }
+
+    this.engineCoordinator.render(timestamp, frameData);
+  }
+
+  handleResize(width, height) {
+    if (this.currentSystem === 'hypercube') {
+      const hypercubeResource = this.canvasPool.getCanvasResources('hypercube', 'content');
+      const rect = hypercubeResource?.canvas?.getBoundingClientRect?.();
+      if (rect) {
+        this.hypercubeSystem?.handleResize?.(rect.width, rect.height);
+      } else {
+        this.hypercubeSystem?.handleResize?.(width, height);
+      }
+    }
+    this.engineCoordinator.resize(width, height);
+  }
+
+  destroy() {
+    this.unsubscribe?.();
+    this.engineCoordinator.destroy();
+    this.canvasPool.destroy();
+    this.resourceManager.dispose();
+    this.reactivityManager?.destroy?.();
+    this.hypercubeSystem?.destroy?.();
+    this.stateManager.destroy();
+  }
 }
+
+export default VisualizerEngine;

--- a/src/holograms/RealHolographicSystem.js
+++ b/src/holograms/RealHolographicSystem.js
@@ -1,723 +1,104 @@
-/**
- * REAL Holographic System - Modified for holo-* canvas IDs
- * Uses the elaborate effects from active-holographic-systems-FIXED
- * Audio reactive only - no mouse/touch/scroll interference
- */
-import { HolographicVisualizer } from './HolographicVisualizer.js';
+import { BaseLayeredEngine } from '../core/BaseLayeredEngine.js';
 
-export class RealHolographicSystem {
-    constructor() {
-        this.visualizers = [];
-        this.currentVariant = 0;
-        this.baseVariants = 30; // Original 30 variations
-        this.totalVariants = 30;
-        this.isActive = false;
-        
-        // Conditional reactivity: Use built-in only if ReactivityManager not active
-        this.useBuiltInReactivity = !window.reactivityManager;
-        
-        // Audio reactivity system
-        this.audioEnabled = false;
-        this.audioContext = null;
-        this.analyser = null;
-        this.frequencyData = null;
-        this.audioData = { bass: 0, mid: 0, high: 0 };
-        
-        // Variant names for display - SEQUENTIAL ORDER
-        this.variantNames = [
-            // 0-3: TETRAHEDRON variations
-            'TETRAHEDRON LATTICE', 'TETRAHEDRON FIELD', 'TETRAHEDRON MATRIX', 'TETRAHEDRON RESONANCE',
-            // 4-7: HYPERCUBE variations
-            'HYPERCUBE LATTICE', 'HYPERCUBE FIELD', 'HYPERCUBE MATRIX', 'HYPERCUBE QUANTUM',
-            // 8-11: SPHERE variations
-            'SPHERE LATTICE', 'SPHERE FIELD', 'SPHERE MATRIX', 'SPHERE RESONANCE',
-            // 12-15: TORUS variations
-            'TORUS LATTICE', 'TORUS FIELD', 'TORUS MATRIX', 'TORUS QUANTUM',
-            // 16-19: KLEIN BOTTLE variations
-            'KLEIN BOTTLE LATTICE', 'KLEIN BOTTLE FIELD', 'KLEIN BOTTLE MATRIX', 'KLEIN BOTTLE QUANTUM',
-            // 20-22: FRACTAL variations
-            'FRACTAL LATTICE', 'FRACTAL FIELD', 'FRACTAL QUANTUM',
-            // 23-25: WAVE variations
-            'WAVE LATTICE', 'WAVE FIELD', 'WAVE QUANTUM',
-            // 26-29: CRYSTAL variations
-            'CRYSTAL LATTICE', 'CRYSTAL FIELD', 'CRYSTAL MATRIX', 'CRYSTAL QUANTUM'
-        ];
-        
-        this.initialize();
-    }
-    
-    initialize() {
-        console.log('🎨 Initializing REAL Holographic System for Active Holograms tab...');
-        this.createVisualizers();
-        this.setupCenterDistanceReactivity(); // NEW: Center-distance grid density changes
-        this.updateVariantDisplay();
-        this.startRenderLoop();
-    }
-    
-    createVisualizers() {
-        // Create the 5 visualizers using HOLO canvas IDs
-        const layers = [
-            { id: 'holo-background-canvas', role: 'background', reactivity: 0.5 },
-            { id: 'holo-shadow-canvas', role: 'shadow', reactivity: 0.7 },
-            { id: 'holo-content-canvas', role: 'content', reactivity: 0.9 },
-            { id: 'holo-highlight-canvas', role: 'highlight', reactivity: 1.1 },
-            { id: 'holo-accent-canvas', role: 'accent', reactivity: 1.5 }
-        ];
-        
-        let successfulLayers = 0;
-        layers.forEach(layer => {
-            try {
-                // Check if canvas element exists
-                const canvas = document.getElementById(layer.id);
-                if (!canvas) {
-                    console.error(`❌ Canvas not found: ${layer.id}`);
-                    return;
-                }
-                
-                console.log(`🔍 Creating holographic visualizer for: ${layer.id}`);
-                const visualizer = new HolographicVisualizer(layer.id, layer.role, layer.reactivity, this.currentVariant);
-                
-                if (visualizer.gl) {
-                    this.visualizers.push(visualizer);
-                    successfulLayers++;
-                    console.log(`✅ Created REAL holographic layer: ${layer.role} (${layer.id})`);
-                } else {
-                    console.error(`❌ No WebGL context for: ${layer.id}`);
-                }
-            } catch (error) {
-                console.error(`❌ Failed to create REAL holographic layer ${layer.id}:`, error);
-            }
-        });
-        
-        console.log(`✅ Created ${successfulLayers}/5 REAL holographic layers`);
-        
-        if (successfulLayers === 0) {
-            console.error('🚨 NO HOLOGRAPHIC VISUALIZERS CREATED! Check canvas elements and WebGL support.');
-        }
-    }
-    
-    setActive(active) {
-        this.isActive = active;
-        
-        if (active) {
-            // Show holographic layers (from clean interface)
-            const holoLayers = document.getElementById('holographicLayers');
-            if (holoLayers) {
-                holoLayers.style.display = 'block';
-            }
-            
-            // Start audio only if globally enabled and not already started
-            if (!this.audioEnabled && window.audioEnabled === true) {
-                this.initAudio();
-            }
-            console.log('🌌 REAL Active Holograms ACTIVATED with audio reactivity');
-        } else {
-            // Hide holographic layers
-            const holoLayers = document.getElementById('holographicLayers');
-            if (holoLayers) {
-                holoLayers.style.display = 'none';
-            }
-            console.log('🌌 REAL Active Holograms DEACTIVATED');
-        }
-    }
-    
-    
-    updateVariantDisplay() {
-        // This will be called by the main UI system
-        const variantName = this.variantNames[this.currentVariant];
-        return {
-            variant: this.currentVariant,
-            name: variantName,
-            geometryType: Math.floor(this.currentVariant / 4)
-        };
-    }
-    
-    nextVariant() {
-        this.updateVariant(this.currentVariant + 1);
-    }
-    
-    previousVariant() {
-        this.updateVariant(this.currentVariant - 1);
-    }
-    
-    randomVariant() {
-        const randomIndex = Math.floor(Math.random() * this.totalVariants);
-        this.updateVariant(randomIndex);
-    }
-    
-    setVariant(variant) {
-        this.updateVariant(variant);
-    }
-    
-    updateParameter(param, value) {
-        // Store custom parameter overrides
-        if (!this.customParams) {
-            this.customParams = {};
-        }
-        this.customParams[param] = value;
-        
-        console.log(`🌌 Updating holographic ${param}: ${value} (${this.visualizers.length} visualizers)`);
-        
-        // CRITICAL FIX: Call updateParameters method on ALL visualizers for immediate render
-        this.visualizers.forEach((visualizer, index) => {
-            try {
-                if (visualizer.updateParameters) {
-                    // Use new updateParameters method with proper parameter mapping
-                    const params = {};
-                    params[param] = value;
-                    visualizer.updateParameters(params);
-                    console.log(`✅ Updated holographic layer ${index} (${visualizer.role}) with ${param}=${value}`);
-                } else {
-                    console.warn(`⚠️ Holographic layer ${index} missing updateParameters method, using fallback`);
-                    // Fallback for older method (direct parameter setting)
-                    if (visualizer.variantParams) {
-                        visualizer.variantParams[param] = value;
-                        
-                        // If it's a geometry type change, regenerate role params with new geometry
-                        if (param === 'geometryType') {
-                            visualizer.roleParams = visualizer.generateRoleParams(visualizer.role);
-                        }
-                        
-                        // Force manual render for older visualizers
-                        if (visualizer.render) {
-                            visualizer.render();
-                        }
-                    }
-                }
-            } catch (error) {
-                console.error(`❌ Failed to update holographic layer ${index}:`, error);
-            }
-        });
-        
-        console.log(`🔄 Holographic parameter update complete: ${param}=${value}`);
-    }
-    
-    // Override updateVariant to preserve custom parameters
-    updateVariant(newVariant) {
-        if (newVariant < 0) newVariant = this.totalVariants - 1;
-        if (newVariant >= this.totalVariants) newVariant = 0;
-        
-        this.currentVariant = newVariant;
-        
-        // Update all visualizers with new variant parameters
-        this.visualizers.forEach(visualizer => {
-            visualizer.variant = this.currentVariant;
-            visualizer.variantParams = visualizer.generateVariantParams(this.currentVariant);
-            visualizer.roleParams = visualizer.generateRoleParams(visualizer.role);
-            
-            // Apply any custom parameter overrides
-            if (this.customParams) {
-                Object.keys(this.customParams).forEach(param => {
-                    visualizer.variantParams[param] = this.customParams[param];
-                });
-            }
-        });
-        
-        this.updateVariantDisplay();
-        console.log(`🔄 REAL Holograms switched to variant ${this.currentVariant + 1}: ${this.variantNames[this.currentVariant]}`);
-    }
-    
-    getCurrentVariantInfo() {
-        return {
-            variant: this.currentVariant,
-            name: this.variantNames[this.currentVariant],
-            geometryType: Math.floor(this.currentVariant / 4)
-        };
-    }
-    
-    /**
-     * Get current parameters for saving/export (CRITICAL for gallery saving)
-     */
-    getParameters() {
-        // Collect parameters from UI sliders - same as other systems
-        const params = {
-            geometry: Math.floor(this.currentVariant / 4), // Extract geometry from variant
-            gridDensity: parseFloat(document.getElementById('gridDensity')?.value || 15),
-            morphFactor: parseFloat(document.getElementById('morphFactor')?.value || 1.0),
-            chaos: parseFloat(document.getElementById('chaos')?.value || 0.2),
-            speed: parseFloat(document.getElementById('speed')?.value || 1.0),
-            hue: parseFloat(document.getElementById('hue')?.value || 320),
-            intensity: parseFloat(document.getElementById('intensity')?.value || 0.6),
-            saturation: parseFloat(document.getElementById('saturation')?.value || 0.8),
-            rot4dXW: parseFloat(document.getElementById('rot4dXW')?.value || 0.0),
-            rot4dYW: parseFloat(document.getElementById('rot4dYW')?.value || 0.0),
-            rot4dZW: parseFloat(document.getElementById('rot4dZW')?.value || 0.0),
-            variant: this.currentVariant
-        };
-        
-        // Apply any custom parameter overrides
-        if (this.customParams) {
-            Object.assign(params, this.customParams);
-        }
-        
-        console.log('🌌 Holographic system getParameters:', params);
-        return params;
-    }
-    
-    async initAudio() {
-        try {
-            this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
-            
-            if (this.audioContext.state === 'suspended') {
-                await this.audioContext.resume();
-            }
-            
-            this.analyser = this.audioContext.createAnalyser();
-            this.analyser.fftSize = 256;
-            this.frequencyData = new Uint8Array(this.analyser.frequencyBinCount);
-            
-            const constraints = {
-                audio: {
-                    echoCancellation: false,
-                    noiseSuppression: false,
-                    autoGainControl: false,
-                    sampleRate: 44100
-                }
-            };
-            
-            const stream = await navigator.mediaDevices.getUserMedia(constraints);
-            const source = this.audioContext.createMediaStreamSource(stream);
-            source.connect(this.analyser);
-            
-            this.audioEnabled = true;
-            console.log('🎵 REAL Holograms audio reactivity enabled');
-        } catch (error) {
-            console.error('REAL Holograms audio initialization failed:', error);
-        }
-    }
-    
-    // NEW: Disable holographic audio (respects global audio toggle)
-    disableAudio() {
-        if (this.audioEnabled) {
-            this.audioEnabled = false;
-            if (this.audioContext) {
-                this.audioContext.close();
-                this.audioContext = null;
-            }
-            this.analyser = null;
-            this.frequencyData = null;
-            this.audioData = { bass: 0, mid: 0, high: 0 };
-            console.log('🎵 REAL Holograms audio reactivity disabled');
-        }
-    }
-    
-    updateAudio() {
-        if (!this.audioEnabled || !this.analyser || !this.isActive || window.audioEnabled === false) return;
-        
-        this.analyser.getByteFrequencyData(this.frequencyData);
-        
-        const bassEnd = Math.floor(this.frequencyData.length * 0.1);
-        const midEnd = Math.floor(this.frequencyData.length * 0.4);
-        
-        let bass = 0, mid = 0, high = 0;
-        
-        for (let i = 0; i < bassEnd; i++) {
-            bass += this.frequencyData[i];
-        }
-        bass /= (bassEnd * 255);
-        
-        for (let i = bassEnd; i < midEnd; i++) {
-            mid += this.frequencyData[i];
-        }
-        mid /= ((midEnd - bassEnd) * 255);
-        
-        for (let i = midEnd; i < this.frequencyData.length; i++) {
-            high += this.frequencyData[i];
-        }
-        high /= ((this.frequencyData.length - midEnd) * 255);
-        
-        // Enhanced audio processing for better visual response
-        const smoothedAudio = {
-            bass: this.smoothAudioValue(bass, 'bass'),
-            mid: this.smoothAudioValue(mid, 'mid'), 
-            high: this.smoothAudioValue(high, 'high'),
-            energy: (bass + mid + high) / 3,
-            rhythm: this.detectRhythm(bass),
-            melody: this.detectMelody(mid, high)
-        };
-        
-        this.audioData = smoothedAudio;
-        
-        // Apply NEW AUDIO REACTIVITY GRID SETTINGS if available
-        if (window.audioReactivitySettings) {
-            this.applyAudioReactivityGrid(smoothedAudio);
-        }
-        
-        // Apply audio reactivity to all visualizers
-        this.visualizers.forEach(visualizer => {
-            visualizer.updateAudio(this.audioData);
-        });
-    }
-    
-    smoothAudioValue(currentValue, type) {
-        if (!this.audioSmoothing) {
-            this.audioSmoothing = { bass: 0, mid: 0, high: 0 };
-        }
-        
-        const smoothingFactor = 0.4;
-        this.audioSmoothing[type] = this.audioSmoothing[type] * smoothingFactor + currentValue * (1 - smoothingFactor);
-        
-        const threshold = 0.05;
-        return this.audioSmoothing[type] > threshold ? this.audioSmoothing[type] : 0;
-    }
-    
-    detectRhythm(bassLevel) {
-        if (!this.previousBass) this.previousBass = 0;
-        const beatDetected = bassLevel > this.previousBass + 0.2;
-        this.previousBass = bassLevel;
-        return beatDetected ? 1.0 : 0.0;
-    }
-    
-    detectMelody(midLevel, highLevel) {
-        const melodicActivity = (midLevel + highLevel) / 2;
-        return melodicActivity > 0.3 ? melodicActivity : 0.0;
-    }
-    
-    applyAudioReactivityGrid(audioData) {
-        const settings = window.audioReactivitySettings;
-        if (!settings || settings.activeVisualModes.size === 0) return;
-        
-        // Get sensitivity multiplier
-        const sensitivityMultiplier = settings.sensitivity[settings.activeSensitivity];
-        
-        // Apply audio changes to different visual modes
-        settings.activeVisualModes.forEach(modeKey => {
-            const [sensitivity, visualMode] = modeKey.split('-');
-            const paramList = settings.visualModes[visualMode];
-            
-            if (!paramList) return;
-            
-            // Calculate audio intensity with sensitivity
-            const audioIntensity = (audioData.energy * sensitivityMultiplier);
-            const bassIntensity = (audioData.bass * sensitivityMultiplier);
-            const rhythmIntensity = (audioData.rhythm * sensitivityMultiplier);
-            
-            paramList.forEach(param => {
-                let currentValue = 0;
-                
-                switch (param) {
-                    case 'hue':
-                        // Color: Audio-reactive hue cycling
-                        if (!this.audioHueBase) this.audioHueBase = 320;
-                        this.audioHueBase += audioIntensity * 5; // Smooth color shifts
-                        currentValue = this.audioHueBase % 360;
-                        break;
-                        
-                    case 'saturation':
-                        // Color: Beat-responsive saturation
-                        currentValue = Math.min(1.0, 0.6 + (rhythmIntensity * 0.4));
-                        break;
-                        
-                    case 'intensity':
-                        // Color: Energy-responsive brightness
-                        currentValue = Math.min(1.0, 0.4 + (audioIntensity * 0.6));
-                        break;
-                        
-                    case 'morphFactor':
-                        // Geometry: Audio-morphing shapes
-                        currentValue = Math.min(2.0, 1.0 + (bassIntensity * 1.0));
-                        break;
-                        
-                    case 'gridDensity':
-                        // Geometry: Beat-responsive density
-                        currentValue = Math.min(100, 15 + (rhythmIntensity * 50));
-                        break;
-                        
-                    case 'chaos':
-                        // Geometry: Energy-chaos correlation
-                        currentValue = Math.min(1.0, audioIntensity * 0.8);
-                        break;
-                        
-                    case 'speed':
-                        // Movement: Tempo-responsive animation
-                        currentValue = Math.min(3.0, 1.0 + (audioIntensity * 2.0));
-                        break;
-                        
-                    case 'rot4dXW':
-                        // Movement: Bass-driven rotation
-                        if (!this.audioRotationXW) this.audioRotationXW = 0;
-                        this.audioRotationXW += bassIntensity * 0.1;
-                        currentValue = this.audioRotationXW % (Math.PI * 2);
-                        break;
-                        
-                    case 'rot4dYW':
-                        // Movement: Mid-frequency rotation
-                        if (!this.audioRotationYW) this.audioRotationYW = 0;
-                        this.audioRotationYW += audioData.mid * sensitivityMultiplier * 0.08;
-                        currentValue = this.audioRotationYW % (Math.PI * 2);
-                        break;
-                        
-                    case 'rot4dZW':
-                        // Movement: High-frequency rotation  
-                        if (!this.audioRotationZW) this.audioRotationZW = 0;
-                        this.audioRotationZW += audioData.high * sensitivityMultiplier * 0.06;
-                        currentValue = this.audioRotationZW % (Math.PI * 2);
-                        break;
-                }
-                
-                // Apply the parameter change
-                if (window.updateParameter && currentValue !== undefined) {
-                    window.updateParameter(param, currentValue.toFixed(2));
-                }
-            });
-        });
-    }
-    
-    setupCenterDistanceReactivity() {
-        if (!this.useBuiltInReactivity) {
-            console.log('✨ Holographic built-in reactivity DISABLED - ReactivityManager active');
-            return;
-        }
-        
-        console.log('✨ Setting up holographic shimmer effects + dramatic color bursts for Holographic system');
-        
-        // Track mouse/touch position for shimmer calculation
-        this.currentX = 0.5;
-        this.currentY = 0.5;
-        
-        // Holographic color burst state (dramatic multi-parameter effects)
-        this.colorBurstIntensity = 0;
-        this.burstHueShift = 0;
-        this.burstIntensityBoost = 0;
-        this.burstSaturationSpike = 0;
-        this.burstChaosEffect = 0;
-        this.burstSpeedBoost = 0;
-        
-        const holographicCanvases = [
-            'holo-background-canvas', 'holo-shadow-canvas', 'holo-content-canvas',
-            'holo-highlight-canvas', 'holo-accent-canvas'
-        ];
-        
-        holographicCanvases.forEach(canvasId => {
-            const canvas = document.getElementById(canvasId);
-            if (!canvas) return;
-            
-            // Mouse movement -> holographic shimmer (like trading card iridescence)
-            canvas.addEventListener('mousemove', (e) => {
-                if (!this.isActive) return;
-                
-                const rect = canvas.getBoundingClientRect();
-                const mouseX = (e.clientX - rect.left) / rect.width;
-                const mouseY = (e.clientY - rect.top) / rect.height;
-                
-                this.updateHolographicShimmer(mouseX, mouseY);
-            });
-            
-            // Touch movement -> holographic shimmer
-            canvas.addEventListener('touchmove', (e) => {
-                if (!this.isActive) return;
-                e.preventDefault();
-                
-                if (e.touches.length > 0) {
-                    const touch = e.touches[0];
-                    const rect = canvas.getBoundingClientRect();
-                    const touchX = (touch.clientX - rect.left) / rect.width;
-                    const touchY = (touch.clientY - rect.top) / rect.height;
-                    
-                    this.updateHolographicShimmer(touchX, touchY);
-                }
-            }, { passive: false });
-            
-            // Click -> dramatic color burst (like Quantum's dramatic effects)
-            canvas.addEventListener('click', (e) => {
-                if (!this.isActive) return;
-                
-                const rect = canvas.getBoundingClientRect();
-                const clickX = (e.clientX - rect.left) / rect.width;
-                const clickY = (e.clientY - rect.top) / rect.height;
-                
-                this.triggerHolographicColorBurst(clickX, clickY);
-            });
-            
-            // Touch end -> dramatic color burst
-            canvas.addEventListener('touchend', (e) => {
-                if (!this.isActive) return;
-                
-                if (e.changedTouches.length > 0) {
-                    const touch = e.changedTouches[0];
-                    const rect = canvas.getBoundingClientRect();
-                    const touchX = (touch.clientX - rect.left) / rect.width;
-                    const touchY = (touch.clientY - rect.top) / rect.height;
-                    
-                    this.triggerHolographicColorBurst(touchX, touchY);
-                }
-            });
-        });
-        
-        // Start holographic color burst animation loop
-        this.startHolographicColorBurstLoop();
-    }
-    
-    updateHolographicShimmer(x, y) {
-        // HOLOGRAPHIC TRADING CARD SHIMMER EFFECTS
-        // Calculate position-based shimmer like real holographic cards
-        
-        // Create iridescent shimmer based on viewing angle (mouse position)
-        const angleX = (x - 0.5) * Math.PI; // -π/2 to π/2 
-        const angleY = (y - 0.5) * Math.PI;
-        
-        // Holographic rainbow shimmer - shifts through spectrum based on angle
-        const baseHue = 320; // Start with magenta-pink
-        const shimmerRange = 120; // Cover 120 degrees of spectrum
-        const hueShimmer = Math.sin(angleX * 2) * Math.cos(angleY * 2) * shimmerRange;
-        const shimmerHue = (baseHue + hueShimmer + 360) % 360;
-        
-        // Iridescent intensity - varies with viewing angle like real holograms
-        const shimmerIntensity = 0.4 + (0.5 * Math.abs(Math.sin(angleX) * Math.cos(angleY)));
-        
-        // Holographic saturation pulse - high saturation for vivid colors
-        const saturationPulse = 0.7 + (0.3 * Math.abs(Math.cos(angleX * 1.5) * Math.sin(angleY * 1.5)));
-        
-        // Subtle depth illusion - slight morph based on angle (much more subtle than faceted)
-        const depthMorph = 1.0 + (0.15 * Math.sin(angleX * 0.8) * Math.cos(angleY * 0.8));
-        
-        // Update holographic shimmer parameters
-        if (window.updateParameter) {
-            window.updateParameter('hue', Math.round(shimmerHue));
-            window.updateParameter('intensity', shimmerIntensity.toFixed(2));
-            window.updateParameter('saturation', saturationPulse.toFixed(2));
-            window.updateParameter('morphFactor', depthMorph.toFixed(2));
-        }
-        
-        console.log(`✨ Holographic shimmer: angle=(${angleX.toFixed(2)}, ${angleY.toFixed(2)}) → Hue=${Math.round(shimmerHue)}, Intensity=${shimmerIntensity.toFixed(2)}`);
-    }
-    
-    triggerHolographicColorBurst(x, y) {
-        // DRAMATIC HOLOGRAPHIC COLOR BURST (like Quantum's dramatic click effects)
-        
-        // Calculate energy based on click position 
-        const centerX = 0.5;
-        const centerY = 0.5;
-        const distanceFromCenter = Math.sqrt((x - centerX) ** 2 + (y - centerY) ** 2);
-        const normalizedDistance = Math.min(distanceFromCenter / 0.707, 1.0);
-        
-        // QUANTUM-STYLE DRAMATIC EFFECTS
-        this.colorBurstIntensity = 1.0; // Full burst intensity
-        
-        // Multi-parameter dramatic effects that decay back
-        this.burstHueShift = 180; // Dramatic hue shift across spectrum
-        this.burstIntensityBoost = 0.7; // Major intensity boost
-        this.burstSaturationSpike = 0.8; // Vivid color spike
-        this.burstChaosEffect = 0.6; // Chaos/morph burst effect
-        this.burstSpeedBoost = 1.8; // Animation speed burst
-        
-        console.log(`🌈💥 HOLOGRAPHIC COLOR BURST: position=(${x.toFixed(2)}, ${y.toFixed(2)}), distance=${distanceFromCenter.toFixed(3)}`);
-    }
-    
-    startHolographicColorBurstLoop() {
-        const burstAnimation = () => {
-            // DRAMATIC HOLOGRAPHIC COLOR BURST ANIMATION (like Quantum's multi-parameter effects)
-            let hasActiveEffects = false;
-            
-            if (this.colorBurstIntensity > 0.01) {
-                hasActiveEffects = true;
-                
-                // Phase-based burst animation with color cycling
-                const burstPhase = this.colorBurstIntensity;
-                
-                // HUE BURST: Cycle through rainbow spectrum
-                if (this.burstHueShift > 1) {
-                    const baseHue = 320; // Holographic magenta base
-                    const currentHueShift = this.burstHueShift * Math.sin(burstPhase * Math.PI * 2);
-                    const burstHue = (baseHue + currentHueShift) % 360;
-                    
-                    if (window.updateParameter) {
-                        window.updateParameter('hue', Math.round(burstHue));
-                    }
-                    this.burstHueShift *= 0.93; // Smooth decay
-                }
-                
-                // INTENSITY BURST: Dramatic brightness flash
-                if (this.burstIntensityBoost > 0.01) {
-                    const baseIntensity = 0.5;
-                    const burstIntensity = Math.min(1.0, baseIntensity + this.burstIntensityBoost * burstPhase);
-                    
-                    if (window.updateParameter) {
-                        window.updateParameter('intensity', burstIntensity.toFixed(2));
-                    }
-                    this.burstIntensityBoost *= 0.92;
-                }
-                
-                // SATURATION SPIKE: Vivid color explosion
-                if (this.burstSaturationSpike > 0.01) {
-                    const baseSaturation = 0.8;
-                    const burstSaturation = Math.min(1.0, baseSaturation + this.burstSaturationSpike * burstPhase);
-                    
-                    if (window.updateParameter) {
-                        window.updateParameter('saturation', burstSaturation.toFixed(2));
-                    }
-                    this.burstSaturationSpike *= 0.91;
-                }
-                
-                // CHAOS/MORPH EFFECT: Geometric distortion burst
-                if (this.burstChaosEffect > 0.01) {
-                    const baseChaos = 0.2;
-                    const burstChaos = baseChaos + this.burstChaosEffect * burstPhase;
-                    
-                    if (window.updateParameter) {
-                        window.updateParameter('chaos', burstChaos.toFixed(2));
-                    }
-                    this.burstChaosEffect *= 0.90;
-                }
-                
-                // SPEED BOOST: Animation acceleration
-                if (this.burstSpeedBoost > 0.01) {
-                    const baseSpeed = 1.0;
-                    const burstSpeed = baseSpeed + this.burstSpeedBoost * burstPhase;
-                    
-                    if (window.updateParameter) {
-                        window.updateParameter('speed', burstSpeed.toFixed(2));
-                    }
-                    this.burstSpeedBoost *= 0.89;
-                }
-                
-                // Master intensity decay
-                this.colorBurstIntensity *= 0.94;
-            }
-            
-            if (this.isActive) {
-                requestAnimationFrame(burstAnimation);
-            }
-        };
-        
-        burstAnimation();
-    }
-    
-    startRenderLoop() {
-        const render = () => {
-            if (this.isActive) {
-                // Update audio reactivity
-                this.updateAudio();
-                
-                // Render all visualizers
-                this.visualizers.forEach(visualizer => {
-                    visualizer.render();
-                });
-            }
-            
-            requestAnimationFrame(render);
-        };
-        
-        render();
-        console.log('🎬 REAL Holographic render loop started');
-    }
-    
-    getVariantName(variant = this.currentVariant) {
-        return this.variantNames[variant] || 'UNKNOWN';
-    }
-    
-    destroy() {
-        this.visualizers.forEach(visualizer => {
-            if (visualizer.destroy) {
-                visualizer.destroy();
-            }
-        });
-        this.visualizers = [];
-        
-        if (this.audioContext) {
-            this.audioContext.close();
-        }
-        
-        console.log('🧹 REAL Holographic System destroyed');
-    }
+const HOLOGRAPHIC_PALETTE = {
+  background: {
+    hueOffset: -60,
+    saturation: 0.55,
+    lightness: 0.15,
+    mix: 0.75,
+    intensity: 0.8,
+    energyImpact: 0.35,
+    beatImpact: 0.2,
+    energyMix: 0.3,
+  },
+  shadow: {
+    hueOffset: -90,
+    saturation: 0.45,
+    lightness: 0.1,
+    mix: 0.35,
+    intensity: 0.55,
+    energyImpact: 0.15,
+    damageImpact: 0.35,
+  },
+  content: {
+    hueOffset: 0,
+    saturation: 0.8,
+    lightness: 0.32,
+    mix: 0.8,
+    intensity: 1.05,
+    energyImpact: 0.5,
+    highlightImpact: 0.55,
+    energyMix: 0.35,
+  },
+  highlight: {
+    hueOffset: 40,
+    saturation: 0.95,
+    lightness: 0.48,
+    mix: 0.85,
+    intensity: 1.25,
+    energyImpact: 0.65,
+    beatImpact: 0.45,
+    highlightImpact: 0.8,
+    energyMix: 0.45,
+  },
+  accent: {
+    hueOffset: 90,
+    hueSpread: 70,
+    saturation: 1.0,
+    lightness: 0.58,
+    mix: 0.9,
+    intensity: 1.35,
+    energyImpact: 0.7,
+    beatImpact: 0.65,
+    highlightImpact: 0.85,
+    energyMix: 0.5,
+  },
+};
+
+export class RealHolographicSystem extends BaseLayeredEngine {
+  constructor(options = {}) {
+    super({
+      ...options,
+      palette: HOLOGRAPHIC_PALETTE,
+    });
+
+    this.hologramState = {
+      shimmer: 0,
+      lensFlare: 0,
+    };
+  }
+
+  getDefaultParameters() {
+    return {
+      ...super.getDefaultParameters(),
+      hue: 180,
+      intensity: 0.7,
+      saturation: 0.9,
+      chaos: 0.15,
+    };
+  }
+
+  onAudioData(audioData = {}) {
+    super.onAudioData(audioData);
+    this.hologramState.shimmer = Math.max(this.hologramState.shimmer, this.audioState.high * 1.2);
+    this.hologramState.lensFlare = Math.max(this.hologramState.lensFlare, this.audioState.mid * 0.8);
+  }
+
+  render(timestamp) {
+    this.effectState.highlight = Math.max(this.effectState.highlight, this.hologramState.shimmer * 0.6);
+    this.effectState.combo = Math.max(this.effectState.combo, this.hologramState.lensFlare * 0.35);
+    super.render(timestamp);
+    this.hologramState.shimmer = Math.max(0, this.hologramState.shimmer * 0.9);
+    this.hologramState.lensFlare = Math.max(0, this.hologramState.lensFlare * 0.9);
+  }
+
+  computeLayerUniforms(pipeline, palette) {
+    const uniforms = super.computeLayerUniforms(pipeline, palette);
+    uniforms.mix = Math.min(1, uniforms.mix + this.hologramState.shimmer * 0.2);
+    uniforms.morph = Math.min(1, uniforms.morph + this.hologramState.lensFlare * 0.25);
+    uniforms.chaos = Math.min(2, uniforms.chaos + this.hologramState.shimmer * 0.3);
+    return uniforms;
+  }
 }
+
+export default RealHolographicSystem;

--- a/src/quantum/QuantumEngine.js
+++ b/src/quantum/QuantumEngine.js
@@ -1,578 +1,107 @@
-/**
- * VIB34D Quantum Engine
- * Manages the enhanced quantum system with complex 3D lattice functions
- */
+import { BaseLayeredEngine } from '../core/BaseLayeredEngine.js';
 
-import { QuantumHolographicVisualizer } from './QuantumVisualizer.js';
-import { ParameterManager } from '../core/Parameters.js';
-import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
+const QUANTUM_PALETTE = {
+  background: {
+    hueOffset: -140,
+    saturation: 0.65,
+    lightness: 0.12,
+    mix: 0.6,
+    intensity: 0.75,
+    energyImpact: 0.45,
+    beatImpact: 0.35,
+    energyMix: 0.35,
+  },
+  shadow: {
+    hueOffset: -170,
+    saturation: 0.55,
+    lightness: 0.1,
+    mix: 0.25,
+    intensity: 0.55,
+    energyImpact: 0.2,
+    damageImpact: 0.4,
+  },
+  content: {
+    hueOffset: -20,
+    saturation: 0.9,
+    lightness: 0.3,
+    mix: 0.7,
+    intensity: 1.1,
+    energyImpact: 0.6,
+    beatImpact: 0.7,
+    highlightImpact: 0.45,
+    energyMix: 0.4,
+  },
+  highlight: {
+    hueOffset: 18,
+    saturation: 1.0,
+    lightness: 0.45,
+    mix: 0.8,
+    intensity: 1.3,
+    energyImpact: 0.7,
+    beatImpact: 0.55,
+    highlightImpact: 0.65,
+    energyMix: 0.45,
+  },
+  accent: {
+    hueOffset: 60,
+    hueSpread: 60,
+    saturation: 1.0,
+    lightness: 0.55,
+    mix: 0.9,
+    intensity: 1.35,
+    energyImpact: 0.75,
+    beatImpact: 0.8,
+    highlightImpact: 0.7,
+    energyMix: 0.5,
+  },
+};
 
-export class QuantumEngine {
-    constructor() {
-        console.log('🔮 Initializing VIB34D Quantum Engine...');
-        
-        this.visualizers = [];
-        this.parameters = new ParameterManager();
-        this.isActive = false;
-        
-        // Conditional reactivity: Use built-in only if ReactivityManager not active
-        this.useBuiltInReactivity = !window.reactivityManager;
-        
-        // Gesture velocity reactivity system for Quantum
-        this.lastMousePosition = { x: 0.5, y: 0.5 };
-        this.mouseVelocity = { x: 0, y: 0 };
-        this.velocityHistory = [];
-        this.maxVelocityHistory = 10;
-        
-        // Base parameter values for gesture modulation
-        this.baseHue = 280; // Purple-blue for quantum
-        this.baseMorphFactor = 1.0;
-        
-        // Initialize with quantum-enhanced defaults
-        this.parameters.setParameter('hue', this.baseHue);
-        this.parameters.setParameter('intensity', 0.7); // Higher intensity
-        this.parameters.setParameter('saturation', 0.9); // More vivid
-        this.parameters.setParameter('gridDensity', 20); // Denser patterns
-        this.parameters.setParameter('morphFactor', this.baseMorphFactor);
-        
-        this.init();
-    }
-    
-    /**
-     * Initialize the quantum system
-     */
-    init() {
-        this.createVisualizers();
-        this.setupAudioReactivity();
-        this.setupGestureVelocityReactivity(); // Additional gesture system
-        this.startRenderLoop();
-        console.log('✨ Quantum Engine initialized with audio + gesture velocity reactivity');
-    }
-    
-    /**
-     * Create quantum visualizers for all 5 layers
-     */
-    createVisualizers() {
-        const layers = [
-            { id: 'quantum-background-canvas', role: 'background', reactivity: 0.4 },
-            { id: 'quantum-shadow-canvas', role: 'shadow', reactivity: 0.6 },
-            { id: 'quantum-content-canvas', role: 'content', reactivity: 1.0 },
-            { id: 'quantum-highlight-canvas', role: 'highlight', reactivity: 1.3 },
-            { id: 'quantum-accent-canvas', role: 'accent', reactivity: 1.6 }
-        ];
-        
-        layers.forEach(layer => {
-            try {
-                // Canvas elements should already exist in HTML
-                const canvas = document.getElementById(layer.id);
-                if (!canvas) {
-                    console.warn(`⚠️ Canvas ${layer.id} not found in DOM - skipping`);
-                    return;
-                }
-                
-                const visualizer = new QuantumHolographicVisualizer(layer.id, layer.role, layer.reactivity, 0);
-                if (visualizer.gl) {
-                    this.visualizers.push(visualizer);
-                    console.log(`🌌 Created quantum layer: ${layer.role}`);
-                } else {
-                    console.warn(`⚠️ No WebGL context for quantum layer ${layer.id}`);
-                }
-            } catch (error) {
-                console.warn(`Failed to create quantum layer ${layer.id}:`, error);
-            }
-        });
-        
-        console.log(`✅ Created ${this.visualizers.length} quantum visualizers with enhanced effects`);
-    }
-    
-    /**
-     * Set system active/inactive
-     */
-    setActive(active) {
-        this.isActive = active;
-        
-        if (active) {
-            // Show quantum layers
-            const quantumLayers = document.getElementById('quantumLayers');
-            if (quantumLayers) {
-                quantumLayers.style.display = 'block';
-            }
-            
-            // Enable audio if global audio is enabled
-            if (window.audioEnabled && !this.audioEnabled) {
-                this.enableAudio();
-            }
-            
-            console.log('🔮 Quantum System ACTIVATED - Audio frequency reactivity mode');
-        } else {
-            // Hide quantum layers
-            const quantumLayers = document.getElementById('quantumLayers');
-            if (quantumLayers) {
-                quantumLayers.style.display = 'none';
-            }
-            console.log('🔮 Quantum System DEACTIVATED');
-        }
-    }
-    
-    // Method to be called when global audio is toggled
-    toggleAudio(enabled) {
-        if (enabled && this.isActive && !this.audioEnabled) {
-            this.enableAudio();
-        } else if (!enabled && this.audioEnabled) {
-            // Disable audio
-            this.audioEnabled = false;
-            if (this.audioContext) {
-                this.audioContext.close();
-                this.audioContext = null;
-            }
-            console.log('🔇 Quantum audio reactivity disabled');
-        }
-    }
-    
-    /**
-     * Setup audio frequency reactivity for Quantum system
-     */
-    setupAudioReactivity() {
-        console.log('🌌 Setting up Quantum audio frequency reactivity');
-        // Audio setup will be triggered when audio is enabled
-    }
-    
-    /**
-     * Setup enhanced multi-parameter reactivity for Quantum system
-     */
-    setupGestureVelocityReactivity() {
-        if (!this.useBuiltInReactivity) {
-            console.log('🌌 Quantum built-in reactivity DISABLED - ReactivityManager active');
-            return;
-        }
-        
-        console.log('🌌 Setting up Quantum: velocity + click + scroll + multi-parameter reactivity');
-        
-        // Enhanced state for smooth effects
-        this.clickFlashIntensity = 0;
-        this.scrollMorph = 1.0; // Base morph factor
-        this.velocitySmoothing = 0.8; // Smoother velocity transitions
-        
-        const quantumCanvases = [
-            'quantum-background-canvas', 'quantum-shadow-canvas', 'quantum-content-canvas',
-            'quantum-highlight-canvas', 'quantum-accent-canvas'
-        ];
-        
-        quantumCanvases.forEach(canvasId => {
-            const canvas = document.getElementById(canvasId);
-            if (!canvas) return;
-            
-            // Mouse movement -> smooth velocity + multiple parameters
-            canvas.addEventListener('mousemove', (e) => {
-                if (!this.isActive) return;
-                
-                const rect = canvas.getBoundingClientRect();
-                const mouseX = (e.clientX - rect.left) / rect.width;
-                const mouseY = (e.clientY - rect.top) / rect.height;
-                
-                this.updateEnhancedQuantumParameters(mouseX, mouseY);
-            });
-            
-            // Touch movement -> same enhanced parameters  
-            canvas.addEventListener('touchmove', (e) => {
-                if (!this.isActive) return;
-                e.preventDefault();
-                
-                if (e.touches.length > 0) {
-                    const touch = e.touches[0];
-                    const rect = canvas.getBoundingClientRect();
-                    const touchX = (touch.clientX - rect.left) / rect.width;
-                    const touchY = (touch.clientY - rect.top) / rect.height;
-                    
-                    this.updateEnhancedQuantumParameters(touchX, touchY);
-                }
-            }, { passive: false });
-            
-            // Click -> quantum flash effect
-            canvas.addEventListener('click', (e) => {
-                if (!this.isActive) return;
-                this.triggerQuantumClick();
-            });
-            
-            // Touch end -> quantum flash effect
-            canvas.addEventListener('touchend', (e) => {
-                if (!this.isActive) return;
-                this.triggerQuantumClick();
-            });
-            
-            // Wheel -> quantum morphing scroll effect
-            canvas.addEventListener('wheel', (e) => {
-                if (!this.isActive) return;
-                e.preventDefault();
-                this.updateQuantumScroll(e.deltaY);
-            }, { passive: false });
-        });
-        
-        // Start smooth animation loops
-        this.startQuantumEffectLoops();
-    }
-    
-    updateEnhancedQuantumParameters(x, y) {
-        // Calculate velocity from position change (smoother)
-        const deltaX = x - this.lastMousePosition.x;
-        const deltaY = y - this.lastMousePosition.y;
-        const velocity = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
-        
-        // Smooth velocity history (reduced from 10 to 5 for responsiveness)
-        this.velocityHistory.push(velocity);
-        if (this.velocityHistory.length > 5) {
-            this.velocityHistory.shift();
-        }
-        
-        // Calculate smoother average velocity
-        const avgVelocity = this.velocityHistory.reduce((sum, v) => sum + v, 0) / this.velocityHistory.length;
-        
-        // EXPERIMENTAL QUANTUM MOUSE MAPPING: X-axis rotation + hemispheric colors
-        
-        // X-AXIS: Direct rotation mapping (smooth 4D rotation)
-        // Map mouse X (0-1) to rotation angle (-π to π for full rotation range)
-        const rotationAngle = (x - 0.5) * Math.PI * 2; // -2π to 2π range
-        const rot4dXW = rotationAngle * 0.5; // Smooth XW rotation
-        const rot4dYW = rotationAngle * 0.3; // Complementary YW rotation
-        const rot4dZW = rotationAngle * 0.2; // Subtle ZW rotation
-        
-        // Y-AXIS: Maintains current behavior (density/complexity)
-        const gridDensity = 10 + (y * 90); // Y position: 10-100 range (unchanged)
-        
-        // HEMISPHERIC COLOR MAPPING: Distance from center affects color zones
-        const centerX = 0.5;
-        const centerY = 0.5;
-        const distanceFromCenter = Math.sqrt(Math.pow(x - centerX, 2) + Math.pow(y - centerY, 2));
-        const normalizedDistance = Math.min(1.0, distanceFromCenter * Math.sqrt(2)); // 0-1 range
-        
-        // Color hemisphere mapping
-        const leftHemisphere = x < 0.5;
-        const topHemisphere = y < 0.5;
-        
-        let baseHue;
-        if (leftHemisphere && topHemisphere) {
-            baseHue = 240; // Blue quadrant
-        } else if (!leftHemisphere && topHemisphere) {
-            baseHue = 300; // Purple quadrant  
-        } else if (leftHemisphere && !topHemisphere) {
-            baseHue = 180; // Cyan quadrant
-        } else {
-            baseHue = 320; // Magenta quadrant
-        }
-        
-        // Distance affects hue variation (center = pure color, edges = shifted)
-        const hueVariation = normalizedDistance * 60; // 0-60 degree shift
-        const hue = (baseHue + hueVariation) % 360;
-        
-        // Other parameters influenced by movement
-        const chaos = Math.min(1.0, avgVelocity * 30); // Velocity affects chaos
-        const speed = 0.5 + Math.min(2.5, avgVelocity * 15); // Movement speed
-        const intensity = 0.3 + (normalizedDistance * 0.7); // Distance affects brightness
-        
-        // Update all parameters for rich visual feedback
-        if (window.updateParameter) {
-            // Rotation parameters (new experimental mapping)
-            window.updateParameter('rot4dXW', rot4dXW.toFixed(3));
-            window.updateParameter('rot4dYW', rot4dYW.toFixed(3)); 
-            window.updateParameter('rot4dZW', rot4dZW.toFixed(3));
-            
-            // Traditional parameters
-            window.updateParameter('chaos', chaos.toFixed(2));
-            window.updateParameter('speed', speed.toFixed(2));
-            window.updateParameter('gridDensity', Math.round(gridDensity));
-            window.updateParameter('intensity', intensity.toFixed(2));
-            window.updateParameter('hue', Math.round(hue));
-        }
-        
-        // Update last position
-        this.lastMousePosition.x = x;
-        this.lastMousePosition.y = y;
-        
-        console.log(`🌌 Quantum EXPERIMENTAL: X=${x.toFixed(2)}→Rot=${rotationAngle.toFixed(2)}, Y=${y.toFixed(2)}→Density=${Math.round(gridDensity)}, Dist=${normalizedDistance.toFixed(2)}→Hue=${Math.round(hue)}, Hemisphere=${leftHemisphere ? 'L' : 'R'}${topHemisphere ? 'T' : 'B'}`);
-    }
-    
-    triggerQuantumClick() {
-        // DRAMATIC QUANTUM ENERGY BURST (multi-parameter)
-        this.clickFlashIntensity = 1.0;
-        
-        // Additional dramatic quantum effects that decay back
-        this.quantumChaosBlast = 0.7; // Chaos energy burst
-        this.quantumSpeedWave = 2.0; // Speed wave effect  
-        this.quantumHueShift = 60; // Color explosion shift
-        
-        console.log('💥 Quantum energy burst: flash + chaos + speed + hue explosion');
-    }
-    
-    updateQuantumScroll(deltaY) {
-        // Scroll affects morph factor smoothly
-        const scrollSpeed = 0.02;
-        const scrollDirection = deltaY > 0 ? 1 : -1;
-        
-        this.scrollMorph += scrollDirection * scrollSpeed;
-        this.scrollMorph = Math.max(0.2, Math.min(2.0, this.scrollMorph)); // Clamp 0.2-2.0
-        
-        // Update morph factor
-        if (window.updateParameter) {
-            window.updateParameter('morphFactor', this.scrollMorph.toFixed(2));
-        }
-        
-        console.log(`🌀 Quantum scroll morph: ${this.scrollMorph.toFixed(2)}`);
-    }
-    
-    startQuantumEffectLoops() {
-        const quantumEffects = () => {
-            let hasActiveEffects = false;
-            
-            // QUANTUM FLASH EFFECT (saturation + morph)
-            if (this.clickFlashIntensity > 0.01) {
-                hasActiveEffects = true;
-                
-                // Flash affects saturation - quantum shimmer effect
-                const flashSaturation = 0.9 + (this.clickFlashIntensity * 0.1); // 0.9-1.0 boost
-                const flashMorph = this.scrollMorph + (this.clickFlashIntensity * 0.5); // Morph boost
-                
-                if (window.updateParameter) {
-                    window.updateParameter('saturation', flashSaturation.toFixed(2));
-                    window.updateParameter('morphFactor', flashMorph.toFixed(2));
-                }
-                
-                // Smooth decay
-                this.clickFlashIntensity *= 0.91;
-            }
-            
-            // DRAMATIC CHAOS BLAST EFFECT (fluid decay)
-            if (this.quantumChaosBlast > 0.01) {
-                hasActiveEffects = true;
-                
-                const baseChaos = 0.3; // Quantum default chaos
-                const currentChaos = baseChaos + this.quantumChaosBlast;
-                
-                if (window.updateParameter) {
-                    window.updateParameter('chaos', Math.min(1.0, currentChaos).toFixed(2));
-                }
-                
-                // Smooth decay
-                this.quantumChaosBlast *= 0.88; // Slightly faster than faceted for quantum energy feel
-            }
-            
-            // DRAMATIC SPEED WAVE EFFECT (fluid decay)  
-            if (this.quantumSpeedWave > 0.01) {
-                hasActiveEffects = true;
-                
-                const baseSpeed = 1.0; // Quantum default speed
-                const currentSpeed = baseSpeed + this.quantumSpeedWave;
-                
-                if (window.updateParameter) {
-                    window.updateParameter('speed', Math.min(3.0, currentSpeed).toFixed(2));
-                }
-                
-                // Smooth wave decay
-                this.quantumSpeedWave *= 0.89;
-            }
-            
-            // QUANTUM HUE EXPLOSION EFFECT (fluid decay)
-            if (this.quantumHueShift > 1) {
-                hasActiveEffects = true;
-                
-                const baseHue = 280; // Quantum purple-blue
-                const currentHue = (baseHue + this.quantumHueShift) % 360;
-                
-                if (window.updateParameter) {
-                    window.updateParameter('hue', Math.round(currentHue));
-                }
-                
-                // Smooth color return
-                this.quantumHueShift *= 0.90;
-            }
-            
-            if (this.isActive) {
-                requestAnimationFrame(quantumEffects);
-            }
-        };
-        
-        quantumEffects();
-    }
-    
-    async enableAudio() {
-        if (this.audioEnabled) return;
-        
-        try {
-            // Request microphone access
-            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-            
-            // Create audio context and analyser
-            this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
-            this.analyser = this.audioContext.createAnalyser();
-            
-            // Configure analyser for frequency analysis
-            this.analyser.fftSize = 256;
-            this.analyser.smoothingTimeConstant = 0.8;
-            this.frequencyData = new Uint8Array(this.analyser.frequencyBinCount);
-            
-            // Connect microphone to analyser
-            const source = this.audioContext.createMediaStreamSource(stream);
-            source.connect(this.analyser);
-            
-            this.audioEnabled = true;
-            console.log('🎵 Quantum audio reactivity enabled');
-            
-        } catch (error) {
-            console.error('❌ Failed to enable Quantum audio:', error);
-            this.audioEnabled = false;
-        }
-    }
-    
-    /**
-     * Update parameter across all quantum visualizers with enhanced integration
-     */
-    updateParameter(param, value) {
-        // Update internal parameter manager
-        this.parameters.setParameter(param, value);
-        
-        // CRITICAL: Apply to all quantum visualizers with immediate render
-        this.visualizers.forEach(visualizer => {
-            if (visualizer.updateParameters) {
-                const params = {};
-                params[param] = value;
-                visualizer.updateParameters(params);
-            } else {
-                // Fallback: direct parameter update with manual render
-                if (visualizer.params) {
-                    visualizer.params[param] = value;
-                    if (visualizer.render) {
-                        visualizer.render();
-                    }
-                }
-            }
-        });
-        
-        console.log(`🔮 Updated quantum ${param}: ${value}`);
-    }
-    
-    /**
-     * Update multiple parameters
-     */
-    updateParameters(params) {
-        Object.keys(params).forEach(param => {
-            this.updateParameter(param, params[param]);
-        });
-    }
-    
-    /**
-     * Update mouse interaction
-     */
-    updateInteraction(x, y, intensity) {
-        this.visualizers.forEach(visualizer => {
-            if (visualizer.updateInteraction) {
-                visualizer.updateInteraction(x, y, intensity);
-            }
-        });
-    }
-    
-    /**
-     * Get current parameters for saving/export
-     */
-    getParameters() {
-        return this.parameters.getAllParameters();
-    }
-    
-    /**
-     * Set parameters from loaded/imported data
-     */
-    setParameters(params) {
-        Object.keys(params).forEach(param => {
-            this.parameters.setParameter(param, params[param]);
-        });
-        this.updateParameters(params);
-    }
-    
-    /**
-     * Start the render loop
-     */
-    startRenderLoop() {
-        if (window.mobileDebug) {
-            window.mobileDebug.log(`🎬 Quantum Engine: Starting render loop with ${this.visualizers?.length} visualizers, isActive=${this.isActive}`);
-        }
-        
-        const render = () => {
-            if (this.isActive) {
-                // MVEP-STYLE AUDIO PROCESSING: Use global audio data instead of internal processing
-                // This eliminates conflicts with holographic system and ensures consistent audio reactivity
-                // Audio reactivity now handled directly in visualizer render loops
-                
-                // CRITICAL FIX: Update visualizer parameters before rendering
-                const currentParams = this.parameters.getAllParameters();
-                
-                this.visualizers.forEach(visualizer => {
-                    if (visualizer.updateParameters && visualizer.render) {
-                        visualizer.updateParameters(currentParams);
-                        visualizer.render();
-                    }
-                });
-                
-                // Mobile debug: Log render activity periodically
-                if (window.mobileDebug && !this._renderActivityLogged) {
-                    window.mobileDebug.log(`🎬 Quantum Engine: Actively rendering ${this.visualizers?.length} visualizers`);
-                    this._renderActivityLogged = true;
-                }
-            } else if (window.mobileDebug && !this._inactiveWarningLogged) {
-                window.mobileDebug.log(`⚠️ Quantum Engine: Not rendering because isActive=false`);
-                this._inactiveWarningLogged = true;
-            }
-            
-            requestAnimationFrame(render);
-        };
-        
-        render();
-        console.log('🎬 Quantum render loop started');
-        
-        if (window.mobileDebug) {
-            window.mobileDebug.log(`✅ Quantum Engine: Render loop started, will render when isActive=true`);
-        }
-    }
-    
-    /**
-     * Update audio reactivity (for universal reactivity system)
-     */
-    // Audio reactivity now handled directly in visualizer render loops
-    
-    /**
-     * Update click effects (for universal reactivity system)
-     */
-    updateClick(intensity) {
-        this.visualizers.forEach(visualizer => {
-            if (visualizer.triggerClick) {
-                visualizer.triggerClick(0.5, 0.5, intensity); // Click at center with intensity
-            }
-        });
-    }
-    
-    /**
-     * Update scroll effects (for universal reactivity system)
-     */
-    updateScroll(velocity) {
-        this.visualizers.forEach(visualizer => {
-            if (visualizer.updateScroll) {
-                visualizer.updateScroll(velocity);
-            }
-        });
-    }
-    
-    /**
-     * Clean up resources
-     */
-    destroy() {
-        // Disconnect from universal reactivity
-        if (window.universalReactivity) {
-            window.universalReactivity.disconnectSystem('quantum');
-        }
-        
-        this.visualizers.forEach(visualizer => {
-            if (visualizer.destroy) {
-                visualizer.destroy();
-            }
-        });
-        this.visualizers = [];
-        console.log('🧹 Quantum Engine destroyed');
-    }
+export class QuantumEngine extends BaseLayeredEngine {
+  constructor(options = {}) {
+    super({
+      ...options,
+      palette: QUANTUM_PALETTE,
+    });
+
+    this.quantumState = {
+      bassPulse: 0,
+      trebleGlitter: 0,
+    };
+  }
+
+  getDefaultParameters() {
+    return {
+      ...super.getDefaultParameters(),
+      hue: 260,
+      intensity: 0.75,
+      saturation: 0.95,
+      gridDensity: 20,
+    };
+  }
+
+  onAudioData(audioData = {}) {
+    super.onAudioData(audioData);
+    this.quantumState.bassPulse = Math.max(this.quantumState.bassPulse, this.audioState.bass * 1.1);
+    this.quantumState.trebleGlitter = Math.max(this.quantumState.trebleGlitter, this.audioState.high * 0.9);
+    this.effectState.chaos = Math.max(this.effectState.chaos, this.audioState.mid * 0.6);
+  }
+
+  render(timestamp) {
+    this.effectState.highlight = Math.max(this.effectState.highlight, this.quantumState.trebleGlitter * 0.5);
+    this.effectState.combo = Math.max(this.effectState.combo, this.quantumState.bassPulse * 0.4);
+    super.render(timestamp);
+    this.quantumState.bassPulse = Math.max(0, this.quantumState.bassPulse * 0.85);
+    this.quantumState.trebleGlitter = Math.max(0, this.quantumState.trebleGlitter * 0.88);
+  }
+
+  computeLayerUniforms(pipeline, palette) {
+    const uniforms = super.computeLayerUniforms(pipeline, palette);
+    const noiseInfluence = (this.parameters.chaos ?? 0) * 0.3 + this.audioState.mid * 0.2;
+    uniforms.chaos = Math.min(2, uniforms.chaos + noiseInfluence);
+    uniforms.mix = Math.min(1, uniforms.mix + this.quantumState.trebleGlitter * 0.25);
+    uniforms.morph = Math.min(1, uniforms.morph + this.quantumState.bassPulse * 0.2);
+    return uniforms;
+  }
 }
+
+export default QuantumEngine;

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,787 @@
+const createLocalStorage = () => {
+  let store = new Map();
+  return {
+    setItem(key, value) {
+      store.set(String(key), String(value));
+      this.lastKey = String(key);
+      this.lastValue = String(value);
+    },
+    getItem(key) {
+      return store.has(String(key)) ? store.get(String(key)) : null;
+    },
+    removeItem(key) {
+      store.delete(String(key));
+    },
+    clear() {
+      store.clear();
+    },
+  };
+};
+
+const elementRegistry = new Map();
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName).toUpperCase();
+    this.children = [];
+    this.style = {};
+    this.dataset = {};
+    this.parentElement = null;
+    this._listeners = new Map();
+    this.ownerDocument = globalThis.document;
+
+    let currentId = null;
+    Object.defineProperty(this, 'id', {
+      get() {
+        return currentId;
+      },
+      set(value) {
+        if (currentId) {
+          elementRegistry.delete(currentId);
+        }
+        currentId = value ? String(value) : null;
+        if (currentId) {
+          elementRegistry.set(currentId, this);
+        }
+      },
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
+  appendChild(child) {
+    if (!child) {
+      return child;
+    }
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+
+  removeChild(child) {
+    if (!child) {
+      return child;
+    }
+    this.children = this.children.filter((candidate) => candidate !== child);
+    if (child.parentElement === this) {
+      child.parentElement = null;
+    }
+    return child;
+  }
+
+  addEventListener(type, listener) {
+    if (!this._listeners.has(type)) {
+      this._listeners.set(type, new Set());
+    }
+    this._listeners.get(type).add(listener);
+  }
+
+  removeEventListener(type, listener) {
+    this._listeners.get(type)?.delete(listener);
+  }
+
+  dispatchEvent(event) {
+    const listeners = this._listeners.get(event?.type) || new Set();
+    [...listeners].forEach((listener) => listener.call(this, event));
+    return true;
+  }
+}
+
+class FakeWebGLContext {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this._lost = false;
+    this.viewportCalls = [];
+    this.clearCalls = [];
+  }
+
+  viewport(x, y, width, height) {
+    this.viewportCalls.push({ x, y, width, height });
+  }
+
+  clearColor(r, g, b, a) {
+    this.clearCalls.push({ r, g, b, a });
+  }
+
+  finish() {}
+
+  isContextLost() {
+    return this._lost;
+  }
+
+  getExtension(name) {
+    if (name === 'WEBGL_lose_context') {
+      return {
+        loseContext: () => {
+          this._lost = true;
+        },
+        restoreContext: () => {
+          this._lost = false;
+        },
+      };
+    }
+    return null;
+  }
+}
+
+class FakeCanvas extends FakeElement {
+  constructor() {
+    super('canvas');
+    this.width = 0;
+    this.height = 0;
+    this._context = null;
+    this.toDataURL = (mimeType = 'image/png') => `data:${mimeType};base64,`;
+  }
+
+  getContext() {
+    if (this._context && !this._context._lost) {
+      return this._context;
+    }
+    this._context = new FakeWebGLContext(this);
+    return this._context;
+  }
+
+  dispatchEvent(event) {
+    if (event?.type === 'webglcontextlost') {
+      if (typeof event.preventDefault === 'function') {
+        event.preventDefault();
+      }
+      if (this._context) {
+        this._context._lost = true;
+      }
+    } else if (event?.type === 'webglcontextrestored') {
+      this._context = null;
+    }
+
+    return super.dispatchEvent(event);
+  }
+}
+
+const testNow = { value: Date.now() };
+global.performance = { now: () => testNow.value };
+global.__setTestNow = (nextNow) => {
+  testNow.value = Number.isFinite(nextNow) ? nextNow : testNow.value;
+};
+
+global.window = {
+  devicePixelRatio: 1,
+  innerWidth: 1280,
+  innerHeight: 720,
+  addEventListener() {},
+  removeEventListener() {},
+  localStorage: createLocalStorage(),
+  performance: global.performance,
+  setTimeout: (...args) => setTimeout(...args),
+  clearTimeout: (...args) => clearTimeout(...args),
+};
+
+const documentBody = new FakeElement('body');
+
+global.document = {
+  body: documentBody,
+  getElementById(id) {
+    return elementRegistry.get(String(id)) || null;
+  },
+  createElement(tag) {
+    return tag.toLowerCase() === 'canvas' ? new FakeCanvas() : new FakeElement(tag);
+  },
+};
+
+global.window.document = global.document;
+
+global.window.requestAnimationFrame = (cb) => setTimeout(() => cb(Date.now()), 16);
+
+global.window.cancelAnimationFrame = (id) => clearTimeout(id);
+
+globalThis.window = global.window;
+
+globalThis.document = global.document;
+
+globalThis.requestAnimationFrame = global.window.requestAnimationFrame;
+
+globalThis.cancelAnimationFrame = global.window.cancelAnimationFrame;
+
+globalThis.navigator = { userAgent: 'node' };
+
+const { StateManager } = await import('../src/core/StateManager.js');
+const { EngineCoordinator } = await import('../src/core/EngineCoordinator.js');
+const { ParameterMappingSystem } = await import('../src/core/ParameterMappingSystem.js');
+const { BaselineCaptureManager } = await import('../src/core/BaselineCaptureManager.js');
+const { CanvasResourcePool } = await import('../src/core/CanvasManager.js');
+const { ResourceManager } = await import('../src/core/ResourceManager.js');
+
+const tests = [];
+
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message || 'Assertion failed');
+  }
+}
+
+class StubEngine {
+  constructor({ systemName }) {
+    this.systemName = systemName;
+    this.active = false;
+    this.parameters = null;
+    this.events = [];
+  }
+
+  async initialize() {
+    this.events.push('initialize');
+  }
+
+  setActive(value) {
+    this.active = value;
+    this.events.push(`setActive:${value}`);
+  }
+
+  handleResize(width, height) {
+    this.lastSize = { width, height };
+    this.events.push('resize');
+  }
+
+  render() {
+    this.events.push('render');
+  }
+
+  async deactivate() {
+    this.events.push('deactivate');
+  }
+
+  async saveState() {
+    this.events.push('saveState');
+  }
+
+  async restoreState() {
+    this.events.push('restoreState');
+  }
+
+  destroy() {
+    this.events.push('destroy');
+  }
+
+  setParameters(parameters) {
+    this.parameters = parameters;
+    this.events.push('setParameters');
+  }
+
+  customHook(payload) {
+    this.customPayload = payload;
+    this.events.push('customHook');
+  }
+}
+
+class StubCanvasPool {
+  constructor() {
+    this.switches = [];
+    this.resizes = [];
+    this.systems = new Set();
+    this.resources = new Map();
+  }
+
+  ensureSystem(systemName) {
+    this.systems.add(systemName);
+  }
+
+  getCanvasResources(systemName, layerName) {
+    const key = `${systemName}-${layerName}`;
+    if (!this.resources.has(key)) {
+      const canvas = {
+        id: key,
+        width: 256,
+        height: 256,
+        toDataURL: (mimeType = 'image/png') => `data:${mimeType};base64,${Buffer.from(key).toString('base64')}`,
+      };
+      const context = {
+        RGBA: 0x1908,
+        UNSIGNED_BYTE: 0x1401,
+        isContextLost: () => false,
+        readPixels: (x, y, width, height, format, type, buffer) => {
+          if (buffer instanceof Uint8Array) {
+            buffer.fill(0);
+          }
+          return { x, y, width, height, format, type };
+        },
+      };
+
+      this.resources.set(key, {
+        canvas,
+        context,
+        contextId: `ctx-${key}`,
+        isValid: true,
+        key: layerName,
+        layerIndex: 0,
+      });
+    }
+
+    return this.resources.get(key);
+  }
+
+  switchToSystem(systemName) {
+    this.switches.push(systemName);
+  }
+
+  handleResize(width, height) {
+    this.resizes.push({ width, height });
+  }
+}
+
+class StubResourceManager {
+  constructor() {
+    this.buffers = [];
+    this.textures = [];
+    this.shaders = [];
+    this.attached = [];
+    this.detached = [];
+    this.released = [];
+  }
+
+  createBuffer(contextId, data) {
+    const id = `buffer-${this.buffers.length + 1}`;
+    const record = { id, handle: { contextId, data }, metadata: { length: data.length } };
+    this.buffers.push(record);
+    return record;
+  }
+
+  createTexture(contextId, options) {
+    const id = `texture-${this.textures.length + 1}`;
+    const record = { id, handle: { contextId, options } };
+    this.textures.push(record);
+    return record;
+  }
+
+  createGradientTexture(contextId) {
+    const record = { id: `texture-gradient`, handle: { contextId, type: 'gradient' } };
+    this.textures.push(record);
+    return record;
+  }
+
+  createNoiseTexture(contextId) {
+    const record = { id: `texture-noise`, handle: { contextId, type: 'noise' } };
+    this.textures.push(record);
+    return record;
+  }
+
+  createShaderSuite(contextId, sources) {
+    const entries = Object.entries(sources).map(([key]) => [key, { id: `shader-${key}`, contextId }]);
+    entries.forEach(([, value]) => this.shaders.push(value));
+    return new Map(entries);
+  }
+
+  attachResourceToUser(resourceId, systemName) {
+    this.attached.push({ resourceId, systemName });
+  }
+
+  detachResourceFromUser(resourceId, systemName) {
+    this.detached.push({ resourceId, systemName });
+  }
+
+  releaseSharedResource(type, key, resource) {
+    this.released.push({ type, key, resource });
+  }
+}
+
+test('StateManager persists and restores critical state', async () => {
+  window.localStorage.clear();
+  const manager = new StateManager();
+
+  manager.dispatch({ type: 'game/updateScore', payload: 500 });
+  manager.dispatch({ type: 'game/setLevel', payload: { level: 3, sublevel: 2 } });
+  manager.dispatch({ type: 'visualization/switchSystem', payload: 'quantum' });
+  manager.dispatch({ type: 'system/setPerformanceLevel', payload: 'medium' });
+
+  manager.persistState();
+
+  assert(window.localStorage.lastKey === 'vib34d_game_state', 'State should persist under expected key');
+  const stored = JSON.parse(window.localStorage.lastValue);
+  assert(stored.game.score === 500, 'Game score should be persisted');
+  assert(stored.visualization.activeSystem === 'quantum', 'Active system should be persisted');
+  assert(stored.system.performanceLevel === 'medium', 'Performance level should be persisted');
+
+  const restoreTarget = new StateManager();
+  window.localStorage.setItem('vib34d_game_state', window.localStorage.lastValue);
+  const restored = restoreTarget.restoreState();
+
+  assert(restored === true, 'restoreState should return true when data is available');
+  assert(restoreTarget.getGameState().score === 500, 'Restored game score should match persisted value');
+  assert(restoreTarget.getVisualizationState().activeSystem === 'quantum', 'Restored visualization system should match persisted value');
+  assert(restoreTarget.getSystemState().performanceLevel === 'medium', 'Restored performance level should match persisted value');
+});
+
+test('StateManager performance instrumentation is synchronous and bounded', () => {
+  const sampleEvents = [];
+  const slowEvents = [];
+  const manager = new StateManager({
+    performance: {
+      enablePerformanceLogging: false,
+      slowReducerThresholdMs: 0,
+      maxPerformanceSamples: 10,
+      onPerformanceSample: (sample) => sampleEvents.push(sample),
+      onSlowReducer: (sample) => slowEvents.push(sample),
+    },
+  });
+
+  manager.registerReducer(
+    'test',
+    (state = 0, action) => {
+      if (action.type === 'test/increment') {
+        return state + 1;
+      }
+      return state;
+    },
+    0,
+  );
+
+  manager.dispatch({ type: 'test/increment' });
+
+  assert(
+    sampleEvents.some((sample) => sample.domain === 'test'),
+    'Performance samples should be recorded synchronously for the registered reducer',
+  );
+  assert(
+    slowEvents.some((sample) => sample.domain === 'test'),
+    'Slow reducer callback should trigger when the configured threshold is met',
+  );
+
+  manager.dispatch({ type: 'test/increment' });
+  manager.dispatch({ type: 'test/increment' });
+  manager.dispatch({ type: 'test/increment' });
+
+  const storedSamples = manager.getPerformanceSamples();
+  assert(
+    storedSamples.length <= 10,
+    'StateManager should retain no more than the configured number of performance samples',
+  );
+  assert(
+    storedSamples.every((sample) => typeof sample.duration === 'number' && sample.duration >= 0),
+    'Recorded performance samples should include reducer durations',
+  );
+});
+
+test('EngineCoordinator orchestrates engine lifecycle', async () => {
+  const canvasPool = new StubCanvasPool();
+  const resourceManager = new StubResourceManager();
+  const actions = [];
+  const stateManager = { dispatch: (action) => actions.push(action) };
+
+  const coordinator = new EngineCoordinator(canvasPool, { resourceManager, stateManager });
+  coordinator.registerEngine('faceted', StubEngine);
+  coordinator.registerEngine('quantum', StubEngine);
+
+  await coordinator.initialize({ initialSystem: 'faceted' });
+
+  const faceted = coordinator.getEngine('faceted');
+
+  assert(faceted instanceof StubEngine, 'Faceted engine should be initialised');
+  assert(
+    coordinator.getEngine('quantum') === null,
+    'Quantum engine should initialise lazily until requested',
+  );
+
+  await coordinator.ensureEngine('quantum');
+  const quantum = coordinator.getEngine('quantum');
+  assert(quantum instanceof StubEngine, 'Quantum engine should be initialised on demand');
+  assert(resourceManager.buffers.length > 0, 'Shared buffers should be created');
+  assert(resourceManager.textures.length > 0, 'Shared textures should be created');
+  assert(resourceManager.shaders.length > 0, 'Shared shaders should be created');
+
+  const firstSwitch = await coordinator.switchEngine('faceted');
+  assert(firstSwitch === true, 'Switching to faceted should succeed');
+  assert(faceted.active === true, 'Faceted engine should become active');
+  assert(canvasPool.switches.includes('faceted'), 'Canvas pool should receive switch request');
+
+  coordinator.applyParameters({ intensity: 0.75 }, 'faceted');
+  assert(faceted.parameters.intensity === 0.75, 'Parameters should be routed to active engine');
+
+  const broadcastHandled = coordinator.broadcast('customHook', { boost: 1 });
+  assert(broadcastHandled === true, 'Broadcast should be handled by engines');
+  assert(faceted.customPayload.boost === 1, 'Broadcast payload should reach engines');
+
+  const secondSwitch = await coordinator.switchEngine('quantum');
+  assert(secondSwitch === true, 'Switching to quantum should succeed');
+  assert(faceted.active === false, 'Previous engine should be deactivated');
+  assert(
+    coordinator.getEngine('faceted') === null,
+    'Previous engine should be released after switching to a new system',
+  );
+  assert(quantum.active === true, 'Target engine should be active');
+  assert(actions.some((action) => action.type === 'visualization/switchSystem' && action.payload === 'quantum'), 'StateManager should receive switch action');
+
+  coordinator.resize(1920, 1080);
+  assert(canvasPool.resizes.length === 1, 'Canvas pool should handle resize');
+  assert(quantum.lastSize.width === 1920, 'Active engine should receive resize dimensions');
+
+  coordinator.destroy();
+  assert(resourceManager.released.length > 0, 'Shared resources should be released on destroy');
+});
+
+test('ParameterMappingSystem fuses audio and interaction data into effective parameters', () => {
+  const now = Date.now();
+  global.__setTestNow(now);
+
+  const baseParameters = {
+    geometry: 2,
+    gridDensity: 20,
+    morphFactor: 0.5,
+    chaos: 0.3,
+    speed: 1.2,
+    hue: 180,
+    intensity: 0.6,
+    saturation: 0.8,
+    dimension: 3.5,
+    rot4dZW: 0.1,
+  };
+
+  const mapper = new ParameterMappingSystem(baseParameters);
+
+  mapper.setInteractionState({
+    mouseMovement: {
+      normalizedX: 0.7,
+      normalizedY: 0.25,
+      velocity: 0.9,
+      lastTimestamp: now,
+    },
+    scroll: {
+      lastDelta: 0.6,
+      lastTimestamp: now,
+    },
+    clickHold: {
+      lastIntensity: 0.5,
+      lastTimestamp: now,
+    },
+    meta: {
+      lastInteractionTimestamp: now,
+    },
+  });
+
+  mapper.setAudioState({
+    bass: 0.5,
+    mid: 0.4,
+    high: 0.3,
+    energy: 0.6,
+  });
+
+  const effective = mapper.getEffectiveParameters();
+  const audioSnapshot = mapper.getAudioState();
+  const interactionSnapshot = mapper.getInteractionState();
+
+  const within = (actual, expected, epsilon = 1e-6) => Math.abs(actual - expected) <= epsilon;
+
+  assert(within(effective.gridDensity, 35), 'Bass should raise grid density according to mapping');
+  assert(within(effective.morphFactor, 0.78), 'Mid frequencies should increase morph factor');
+  assert(within(effective.speed, 1.392), 'Energy should scale speed multiplicatively');
+  assert(within(effective.chaos, 0.3), 'Idle decay should preserve chaos when interaction is fresh');
+  assert(within(effective.hue, 204), 'Mouse X should shift hue symmetrically');
+  assert(within(effective.saturation, 0.84), 'Mouse Y should modulate saturation');
+  assert(within(effective.dimension, 3.56), 'Scroll intensity should adjust dimension within bounds');
+  assert(within(effective.rot4dZW, 0.7), 'Click intensity should steer 4D rotation');
+  assert(within(effective.intensity, 0.72), 'High frequencies should brighten intensity');
+
+  assert(within(effective.audioBass, 0.5), 'Audio bass should be exposed for downstream consumers');
+  assert(within(effective.audioMid, 0.4), 'Audio mid should be exposed for downstream consumers');
+  assert(within(effective.audioHigh, 0.3), 'Audio high should be exposed for downstream consumers');
+  assert(within(effective.audioEnergy, 0.6), 'Audio energy should be exposed for downstream consumers');
+
+  const baseSnapshot = mapper.getBaseParameters();
+  assert(within(baseSnapshot.gridDensity, 20), 'Base grid density should remain unchanged');
+  assert(within(baseSnapshot.morphFactor, 0.5), 'Base morph factor should remain unchanged');
+  assert(audioSnapshot.bass === 0.5 && audioSnapshot.mid === 0.4, 'Audio snapshot should capture mapped bands');
+  assert(
+    interactionSnapshot.mouseMovement.normalizedX === 0.7
+      && interactionSnapshot.scroll.lastDelta === 0.6,
+    'Interaction snapshot should preserve recent interactions',
+  );
+});
+
+test('BaselineCaptureManager captures baseline frames and restores the active system', async () => {
+  const canvasPool = new StubCanvasPool();
+  const resourceManager = new StubResourceManager();
+  const stateManager = new StateManager();
+  const coordinator = new EngineCoordinator(canvasPool, { resourceManager, stateManager });
+
+  coordinator.registerEngine('faceted', StubEngine, { requiredLayers: ['content'] });
+  coordinator.registerEngine('quantum', StubEngine, { requiredLayers: ['content'] });
+
+  await coordinator.initialize({ initialSystem: 'faceted' });
+  await coordinator.ensureEngine('quantum');
+  await coordinator.switchEngine('faceted');
+
+  const mapper = new ParameterMappingSystem({ gridDensity: 12, intensity: 0.4 });
+  const clock = (() => {
+    let value = 0;
+    return () => {
+      value += 16;
+      return value;
+    };
+  })();
+
+  const captureManager = new BaselineCaptureManager({
+    engineCoordinator: coordinator,
+    canvasPool,
+    parameterMappingSystem: mapper,
+    clock,
+  });
+
+  const captures = await captureManager.captureBaselines([
+    {
+      systemName: 'quantum',
+      parameters: { gridDensity: 18, intensity: 0.5 },
+      frames: 2,
+      settleMs: 0,
+    },
+  ]);
+
+  assert(Array.isArray(captures) && captures.length === 1, 'Capture should return a single baseline result');
+  const quantumBaseline = captures[0];
+  assert(quantumBaseline.systemName === 'quantum', 'Baseline should include the requested system name');
+  assert(quantumBaseline.frames.length === 2, 'Baseline should include requested frame count');
+  assert(/^data:image\/png/.test(quantumBaseline.frames[0].dataUrl), 'Baseline should capture canvas data URL');
+  assert(quantumBaseline.effectiveParameters.gridDensity === 18, 'Baseline should record effective grid density');
+  assert(mapper.getBaseParameters().gridDensity === 12, 'Parameter mapper should be restored to original base values');
+  assert(coordinator.getActiveSystem() === 'faceted', 'Active system should be restored after capture completes');
+});
+
+test('CanvasResourcePool recovers contexts and releases GPU resources on loss', () => {
+  const resourceManager = new ResourceManager();
+  resourceManager.stopMonitoring();
+
+  const pool = new CanvasResourcePool({
+    systems: ['faceted'],
+    layerSchemas: {
+      faceted: [
+        { key: 'background' },
+        { key: 'content' },
+      ],
+    },
+    resourceManager,
+  });
+
+  pool.initialize({ initialSystem: 'faceted' });
+  const initial = pool.getCanvasResources('faceted', 'content');
+
+  assert(initial && initial.context, 'CanvasResourcePool should provide a WebGL context');
+
+  const disposeLog = [];
+  resourceManager.trackResource(
+    initial.contextId,
+    'buffer',
+    { name: 'test-buffer' },
+    (gl, handle, metadata) => {
+      disposeLog.push({ gl, handle, metadata });
+    },
+    { size: 1024, lastUsed: 0 },
+  );
+
+  const contextBeforeLoss = resourceManager.contexts.get(initial.contextId);
+  assert(contextBeforeLoss && contextBeforeLoss.lost === false, 'Context should start healthy');
+
+  initial.canvas.dispatchEvent({ type: 'webglcontextlost', preventDefault() {} });
+
+  const contextAfterLoss = resourceManager.contexts.get(initial.contextId);
+  assert(contextAfterLoss && contextAfterLoss.lost === true, 'Context should be marked lost after event');
+  assert(resourceManager.resources.size === 0, 'Resources should be released when context is lost');
+  assert(disposeLog.length === 1, 'Dispose callback should run when releasing resources');
+  assert(resourceManager.memoryUsage.total === 0, 'Memory usage should be reset after releasing resources');
+
+  const invalid = pool.getCanvasResources('faceted', 'content');
+  assert(invalid.isValid === false, 'Canvas resource should be invalid while the context is lost');
+
+  initial.canvas.dispatchEvent({ type: 'webglcontextrestored' });
+
+  const restored = pool.getCanvasResources('faceted', 'content');
+  assert(restored.context !== initial.context, 'Recovered context should be a fresh instance');
+  assert(restored.isValid === true, 'Recovered context should be valid');
+
+  const contextAfterRestore = resourceManager.contexts.get(restored.contextId);
+  assert(contextAfterRestore && contextAfterRestore.lost === false, 'Context should be healthy after recovery');
+
+  resourceManager.dispose();
+  pool.destroy();
+});
+
+test('ResourceManager frees least recently used resources when memory pressure exceeds threshold', () => {
+  const resourceManager = new ResourceManager();
+  resourceManager.stopMonitoring();
+
+  const canvas = document.createElement('canvas');
+  const gl = canvas.getContext('webgl');
+  resourceManager.registerWebGLContext('ctx-memory', gl, { label: 'memory' });
+
+  const disposeLog = [];
+
+  const recordResource = (id) => (glRef, handle, metadata) => {
+    disposeLog.push({ id, gl: glRef, handle, metadata });
+  };
+
+  const bufferA = resourceManager.trackResource('ctx-memory', 'buffer', { id: 'A' }, recordResource('bufferA'), {
+    size: 512,
+    lastUsed: 10,
+  });
+  const bufferB = resourceManager.trackResource('ctx-memory', 'buffer', { id: 'B' }, recordResource('bufferB'), {
+    size: 512,
+    lastUsed: 40,
+  });
+  const textureA = resourceManager.trackResource('ctx-memory', 'texture', { id: 'T' }, recordResource('textureA'), {
+    size: 512,
+    lastUsed: 5,
+  });
+
+  resourceManager.maxMemoryUsage = 1024;
+  resourceManager.cleanupThreshold = 0.5;
+
+  resourceManager.checkMemoryPressure();
+
+  assert(
+    disposeLog.some((entry) => entry.id === 'textureA'),
+    'Least recently used resource should be released first',
+  );
+  assert(
+    disposeLog.some((entry) => entry.id === 'bufferA'),
+    'Older buffer should be released to relieve memory pressure',
+  );
+  assert(
+    !disposeLog.some((entry) => entry.id === 'bufferB'),
+    'Most recently used buffer should remain allocated',
+  );
+
+  const remainingResources = [...resourceManager.resources.keys()];
+  assert(
+    remainingResources.length === 1 && remainingResources[0] === bufferB,
+    'Only the most recently used buffer should remain',
+  );
+  assert(
+    resourceManager.memoryUsage.total <= resourceManager.maxMemoryUsage * resourceManager.cleanupThreshold,
+    'Memory usage should fall beneath the cleanup threshold after pressure check',
+  );
+
+  resourceManager.releaseResource(bufferB);
+  resourceManager.dispose();
+});
+
+async function run() {
+  const results = [];
+  for (const { name, fn } of tests) {
+    try {
+      await fn();
+      console.log(`✅ ${name}`);
+      results.push({ name, status: 'passed' });
+    } catch (error) {
+      console.error(`❌ ${name}`);
+      console.error(error);
+      results.push({ name, status: 'failed', error });
+    }
+  }
+
+  const failed = results.filter((result) => result.status === 'failed');
+  if (failed.length > 0) {
+    process.exitCode = 1;
+  } else {
+    console.log(`\nAll ${results.length} tests passed.`);
+  }
+}
+
+await run();


### PR DESCRIPTION
## Summary
- extend the Node smoke harness with DOM/WebGL test doubles to simulate canvas context loss and GPU memory pressure
- add regression tests that validate CanvasResourcePool recovery and ResourceManager cleanup behaviour
- update the architecture progress log to record the new coverage and refresh the outstanding tasks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5ec4506048329914af0ba26381297